### PR TITLE
docs: Document the templateByUri query.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ SnapWP Helper is a WordPress plugin that allows you to quickly install WPGraphQL
 ## Documentation
 
 - [Actions & Filters](docs/hooks.md)
-- [templateByUri query](docs/graphql-queries.md)
+- [GraphQL Queries](docs/graphql-queries.md)
 
 ## Local Development, Testing, and Contribution
 


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->
## What
This PR adds documentation for the GraphQL queries exposed by the SnapWP Helper plugin, specifically focusing on the `templateByUri` query. It also updates the main README.md file to include a link to the new documentation.

## Why
Documentation is crucial for users to understand and effectively use the plugin's features. This PR addresses the need for clear, comprehensive documentation of the GraphQL queries, making it easier for developers to integrate and utilize the plugin in their projects.

### Related Issue(s):
- Closes #6 (Docs: Add docs for GraphQL Queries)

## How
1. Created a new file `docs/graphql-queries.md` with detailed documentation for the `templateByUri` query.
2. Updated the main `README.md` file to include a link to the new documentation.

The documentation includes:
- Query structure
- Arguments
- Return fields
- Usage examples for different scenarios (blog post, category archive, author archive)

## Testing Instructions
1. Clone the repository and checkout this branch.
2. Navigate to the project root directory.
3. Open `docs/graphql-queries.md` and verify that the content is complete and accurate.
4. Open `README.md` and check that there's a new link to the GraphQL queries documentation.
5. If possible, try running the example queries against a test WordPress installation with the plugin activated to ensure they work as documented.

## Screenshots
N/A (Documentation changes only)

## Additional Info
N/A

## Checklist
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc).
- [x] My code has detailed inline documentation.
- [ ] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.