### PR TITLE
chore: (tmp) Drop WPGraphQL Content Blocks min to 4.1.0

### DIFF
--- a/src/Modules/GraphQL.php
+++ b/src/Modules/GraphQL.php
@@ -122,7 +122,7 @@ class GraphQL implements Module {
 	 * @return array{slug:string,name:string,check_callback:callable():(true|\WP_Error)}
 	 */
 	protected function get_wpgraphql_content_blocks_dependency_args(): array {
-		$minimum_version = '4.2.0';
+		$minimum_version = '4.1.0';
 
 		return [
 			'slug'           => 'wp-graphql-content-blocks',


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR _temporarily_ drops the minimum WPGraphQL Content Blocks version to `v4.1.0`.

> [!IMPORTANT]
> This is a temporary measure and a _code-only_ change. For all intents and purposes, we should continue to develop with v4.2.0+

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
Works around https://github.com/wpengine/wp-graphql-content-blocks/issues/311

This was not caught in #10 

### Related Issue(s):
<!-- E.g.
- Fixes #123
- Closes #456
-->

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->

Only the version used in the check is changed. Build scripts et al. still use 4.2.0

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots
<!-- Include relevant screenshots proving the PR works as indended. -->

## Additional Info
<!-- Please include any relevant logs, error output, etc -->

## Checklist
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too. -->
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.
