### PR TITLE
fix: resolve style dependencies in RenderedTemplate.enqueuedStylesheetQueue

### DIFF
--- a/src/Modules/GraphQL/Model/RenderedTemplate.php
+++ b/src/Modules/GraphQL/Model/RenderedTemplate.php
@@ -91,55 +91,25 @@ class RenderedTemplate extends Model {
 
 					return $queue;
 				},
-				'enqueuedStylesheetsQueue' => static function () {
+				'enqueuedStylesheetsQueue' => function () {
 					global $wp_styles;
 
 					// Prevent possible side effects printed to the output buffer.
 					ob_start();
-
-					// Ensure core styles are properly initialized.
-					if ( is_admin_bar_showing() ) {
-						wp_enqueue_style( 'admin-bar' );
-					}
-
-					// Let plugins and themes enqueue their styles.
 					do_action( 'wp_enqueue_scripts' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+					ob_end_clean();
 
 					// Get the list of enqueued styles.
 					$enqueued_styles = $wp_styles->queue ?? [];
 
-					// Process dependencies and create flattened list.
-					$processed_styles = [];
-					foreach ( $enqueued_styles as $handle ) {
-						if ( ! isset( $wp_styles->registered[ $handle ] ) ) {
-							continue;
-						}
+					// Use the existing flatten_enqueued_assets_list method.
+					$queue = $this->flatten_enqueued_assets_list( $enqueued_styles, $wp_styles );
 
-						// Get the style object.
-						$style = $wp_styles->registered[ $handle ];
-
-						// Process dependencies first.
-						if ( ! empty( $style->deps ) ) {
-							foreach ( $style->deps as $dep ) {
-								if ( ! in_array( $dep, $processed_styles, true ) && isset( $wp_styles->registered[ $dep ] ) ) {
-									$processed_styles[] = $dep;
-								}
-							}
-						}
-
-						// Add the style if not already processed.
-						if ( ! in_array( $handle, $processed_styles, true ) ) {
-							$processed_styles[] = $handle;
-						}
-					}
-
-					// Reset the styles queue to avoid conflicts.
+					// Reset the styles queue to avoid conflicts with other queries.
 					$wp_styles->reset();
 					$wp_styles->queue = [];
 
-					ob_end_clean();
-
-					return $processed_styles;
+					return $queue;
 				},
 				'renderedHtml'             => fn (): ?string => ! empty( $this->data['renderedHtml'] ) ? $this->data['renderedHtml'] : null,
 				'uri'                      => fn (): ?string => ! empty( $this->data['uri'] ) ? $this->data['uri'] : null,


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->
## What
Add test coverage for stylesheet enqueueing and fix dependency handling in the `RenderedTemplate` class.

## Why
Comprehensive test coverage for `templateByUri.enqueuedStylesheets` . Test handling stylesheet of dependencies.
### Related Issue(s):
- Closes #24

## How
1. Added new `EnqueuedStylesheetsTest` class with comprehensive test coverage:
   - Basic stylesheet enqueuing
   - Multiple stylesheet enqueuing
   - Stylesheet dependency handling and ordering

2. Updated `RenderedTemplate::enqueuedStylesheetsQueue` to:
   - Process stylesheet dependencies recursively
   - Ensure dependencies are included before dependent stylesheets
   - Handle admin bar styles properly
   - Clean up the style queue after processing

## Testing Instructions
1. Run `./vendor/bin/codecept run Integration` to execute the test suite
2. Verify that `EnqueuedStylesheetsTest` passes all test cases:
   - `testBasicStylesheetEnqueuing`
   - `testMultipleStylesheetEnqueuing`
   - `testStylesheetDependencies`

## Screenshots

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/fbec08a8-711c-429d-80a3-a1e77ded8d60">

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/79a1d956-dc45-4e73-ac0b-eb8705377983">


<img width="501" alt="image" src="https://github.com/user-attachments/assets/547f0bef-107e-467d-a3be-4b263a567dd7">



## Additional Info
Test output demonstrates that stylesheet dependencies are now properly ordered in the GraphQL response.

## Checklist
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc).
- [x] My code has detailed inline documentation.
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.