### PR TITLE
Fix: Back-port compatibility fixes for wp-graphql-content-blocks to SnapWP Helper plugin

### DIFF
--- a/src/Modules/GraphQL/Data/ContentBlocksResolver.php
+++ b/src/Modules/GraphQL/Data/ContentBlocksResolver.php
@@ -25,7 +25,6 @@ final class ContentBlocksResolver {
 	 * @return array<string,mixed> The list of content blocks.
 	 */
 	public static function resolve_content_blocks( $node, $args, $allowed_block_names = [] ): array {
-		global $post_id;
 
 		/**
 		 * When this filter returns a non-null value, the content blocks resolver will use that value


### PR DESCRIPTION
## What

In this PR, I backported specific compatibility fixes from `wp-graphql-content-blocks` to `snapwp-helper` to resolve issues noted in [issue #224](https://github.com/rtCamp/headless/issues/224). The main updates include adjustments to the `ContentBlocksResolver.php` and the `SchemaFilters.php` file.

## Why

This change is necessary because `snapwp-helper` was getting incompatible with `WPGraphQL Content Blocks 4.2.0`. This incompatibility was causing issues. Backporting these changes allows `snapwp-helper` to remain compatible with WPGraphQL Content Blocks plugin.

### Related Issue(s):
Closes https://github.com/rtCamp/headless/issues/231

## How

1. Reviewed Fixes: I focused on the relevant code sections in [snapwp-helper#25](https://github.com/rtCamp/snapwp-helper/pull/25) and [wp-graphql-content-blocks#31](https://github.com/rtCamp/wp-graphql-content-blocks/pull/31), specifically examining:
- `src/Modules/GraphQL/Data/ContentBlocksResolver.php`
- `src/Modules/GraphQL/SchemaFilter.php`

2. Backported Compatibility Changes: I back ported over the necessary code from `wp-graphql-content-blocks` into `snapwp-helper`.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open GraphiQL IDE.
2. Enter the following query:
```
query GetCurrentTemplate($uri: String!) {
  templateByUri(uri: $uri) {
    editorBlocks {
      name
      ... on CoreQueryNoResults{
        renderedHtml
      }
    }
  }
}
```
3. Expect the following response (pfa screenshot)

## Screenshots
<img width="1712" alt="Screenshot 2024-11-06 at 11 21 48 AM" src="https://github.com/user-attachments/assets/02b726bc-614a-41f5-a0f4-51b1f93a876a">


## Checklist
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.
