### PR TITLE
Update : Bump WPGraphql-content-blocks minimum version requirement to `4.2.0`

### DIFF
--- a/src/Modules/GraphQL.php
+++ b/src/Modules/GraphQL.php
@@ -122,7 +122,7 @@ class GraphQL implements Module {
 	 * @return array{slug:string,name:string,check_callback:callable():(true|\WP_Error)}
 	 */
 	protected function get_wpgraphql_content_blocks_dependency_args(): array {
-		$minimum_version = '4.1.0'; // @todo bump to 4.2.x when bugfix is released. See https://github.com/rtCamp/snapwp-helper/issues/9
+		$minimum_version = '4.2.0';
 
 		return [
 			'slug'           => 'wp-graphql-content-blocks',


### PR DESCRIPTION
## What
This PR bumps the minimum version requirement of WPGraphql Content Block plugin from `v4.1.0` to `v4.2.0`.

## Why
The newer version of **WPGraphql Content Block plugin - v4.2.0** consists of many of our [contributions](https://github.com/rtCamp/wp-contributions/issues/477) that have been merged into the latest version of WPGraphQL Content Blocks.

### Related Issue(s):
- Closes #9 

## How
This PR updates the minimum version number requirement by updating the `$minimum_version` present at `src/Modules/GraphQL/GraphQL.php:get_wpgraphql_content_blocks_dependency_args`.

### Note:
The other important location mentioned for the version updation was `bin/install-plugins.sh` where the version for the plugin was already updated to `v4.2.0`.

## Testing Instructions
1. Open site shell and navigate to `SnapWP-Helper` plugin dir.
2. Run the following command to run the Integration test suite:
```
vendor/bin/codecept run Integration
```
3. Observe No failures.

## Screenshots
<!-- Include relevant screenshots proving the PR works as indended. -->
<img width="1026" alt="Screenshot 2024-11-06 at 6 05 58 PM" src="https://github.com/user-attachments/assets/38ae6bc9-8cab-40f2-b191-9ea42837baf9">

## Checklist
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too. -->
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.
