### PR TITLE
ci: Update the latest version of WPGraphQL Content Blocks

### DIFF
--- a/bin/install-plugins.sh
+++ b/bin/install-plugins.sh
@@ -29,7 +29,7 @@ wp plugin activate wp-graphql --allow-root
 
 # WPGraphQL Content Blocks plugin.
 if ! $( wp plugin is-installed wp-graphql-content-blocks --allow-root ); then
-	wp plugin install https://github.com/wpengine/wp-graphql-content-blocks/releases/download/v4.2.0/wp-graphql-content-blocks.zip --allow-root
+	wp plugin install https://github.com/wpengine/wp-graphql-content-blocks/releases/download/latest/wp-graphql-content-blocks.zip --allow-root
 fi
 wp plugin activate wp-graphql-content-blocks --allow-root
 


### PR DESCRIPTION
## What
Update test environment to use the latest WPGraphQL Content Blocks release instead of a fixed version.

## Why
Currently, we test against a specific version of WPGraphQL Content Blocks, requiring manual version bumps for compatibility testing. This change ensures continuous testing against the latest stable release.

### Related Issue(s):
- Fixes #34

## How
Updated the installation URL to use:
`https://github.com/wpengine/wp-graphql-content-blocks/releases/download/latest/wp-graphql-content-blocks.zip`

This ensures our test suite always runs against the most recent stable release.


## Checklist
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md)
- [x] My code is tested to the best of my abilities
- [x] My code passes all lints
- [ ] My code has detailed inline documentation
- [ ] I have added unit tests
- [ ] I have updated project documentation