### PR TITLE
fix: return correct `EnqueuedScript.location` for group

### DIFF
--- a/src/Modules/GraphQL/Type/Fields/EnqueuedScript.php
+++ b/src/Modules/GraphQL/Type/Fields/EnqueuedScript.php
@@ -35,10 +35,10 @@ final class EnqueuedScript extends AbstractFields {
 				'description' => __( 'The location where this script should be loaded', 'snapwp-helper' ),
 				'resolve'     => static function ( \_WP_Dependency $script ) {
 					if ( isset( $script->extra['group'] ) && 1 === (int) $script->extra['group'] ) {
-						return 'header';
+						return 'footer';
 					}
 
-					return 'footer';
+					return 'header';
 				},
 			],
 		];

--- a/tests/Integration/EnqueuedScriptsTest.php
+++ b/tests/Integration/EnqueuedScriptsTest.php
@@ -74,6 +74,7 @@ class EnqueuedScriptsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 					enqueuedScripts(first: 1000) {
 						nodes {
 							handle
+							location
 						}
 					}
 				}
@@ -118,11 +119,12 @@ class EnqueuedScriptsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertArrayHasKey( 'data', $actual );
 
-		// Extract the 'handle' values from the response.
-		$handles = array_column( $actual['data']['templateByUri']['enqueuedScripts']['nodes'], 'handle' );
-
-		// Assert that the script is returned in the enqueuedScriptsQueue.
-		$this->assertContains( 'test-head-script', $handles );
+		// Get the index to test the 'test-head-script' handle.
+		$index = array_search( 'test-head-script', array_column( $actual['data']['templateByUri']['enqueuedScripts']['nodes'], 'handle' ) );
+		$this->assertNotFalse( $index );
+		$actual_script = $actual['data']['templateByUri']['enqueuedScripts']['nodes'][ $index ];
+		$this->assertEquals( 'test-head-script', $actual_script['handle'] );
+		$this->assertEquals( 'header', $actual_script['location'] );
 
 		// Assert only the expected script is enqueued by checking unwanted handles are absent.
 		$this->assertNoUnexpectedScriptsEnqueued( $actual, [ 'test-content-script', 'test-footer-script', 'dependency-script', 'test-dependent-script' ] );
@@ -167,10 +169,13 @@ class EnqueuedScriptsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertArrayHasKey( 'data', $actual );
 
 		// Extract the 'handle' values from the response.
-		$handles = array_column( $actual['data']['templateByUri']['enqueuedScripts']['nodes'], 'handle' );
-
-		// Assert that the script is returned in the enqueuedScriptsQueue.
-		$this->assertContains( 'test-content-script', $handles );
+		
+		// Get the index to test the 'test-content-script' handle.
+		$index = array_search( 'test-content-script', array_column( $actual['data']['templateByUri']['enqueuedScripts']['nodes'], 'handle' ) );
+		$this->assertNotFalse( $index );
+		$actual_script = $actual['data']['templateByUri']['enqueuedScripts']['nodes'][ $index ];
+		$this->assertEquals( 'test-content-script', $actual_script['handle'] );
+		$this->assertEquals( 'header', $actual_script['location'] );
 
 		// Assert only the expected script is enqueued by checking unwanted handles are absent.
 		$this->assertNoUnexpectedScriptsEnqueued( $actual, [ 'test-head-script', 'test-footer-script', 'dependency-script', 'test-dependent-script' ] );
@@ -215,11 +220,11 @@ class EnqueuedScriptsTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertArrayHasKey( 'data', $actual );
 
-		// Extract the 'handle' values from the response.
-		$handles = array_column( $actual['data']['templateByUri']['enqueuedScripts']['nodes'], 'handle' );
-
-		// Assert that the script is returned in the enqueuedScriptsQueue.
-		$this->assertContains( 'test-footer-script', $handles );
+		// Get the index to test the 'test-footer-script' handle.
+		$index = array_search( 'test-footer-script', array_column( $actual['data']['templateByUri']['enqueuedScripts']['nodes'], 'handle' ) );
+		$this->assertNotFalse( $index );
+		$actual_script = $actual['data']['templateByUri']['enqueuedScripts']['nodes'][ $index ];
+		$this->assertEquals( 'test-footer-script', $actual_script['handle'] );
 
 		// Assert only the expected script is enqueued by checking unwanted handles are absent.
 		$this->assertNoUnexpectedScriptsEnqueued( $actual, [ 'test-head-script', 'test-content-script', 'dependency-script', 'test-dependent-script' ] );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

Fixes an issue where `EnqueuedScript.location` was reversing the `header`|`footer` value based on the script group.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
Unblocks https://github.com/rtCamp/headless/pull/261
### Related Issue(s):
<!-- E.g.
- Fixes #123
- Closes #456
-->
Part of https://github.com/rtCamp/headless/issues/219

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots
<!-- Include relevant screenshots proving the PR works as indended. -->

## Additional Info
<!-- Please include any relevant logs, error output, etc -->

## Checklist
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too. -->
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.
