### PR TITLE
ci: remove interfering `--protocol` from `install_db` command

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -4,9 +4,8 @@ PLUGIN_SLUG=snapwp-helper
 ## Usually, these values should match the ones in the `wp-config.php` file.
 ## If using LocalWP, you can find the values in the LocalWP app under the site's settings.
 
-# NOTE: Codeception may modify or the database during testing. If you want to preserve your local data, create a new database and use that for the `DB_NAME`.
+# NOTE: Codeception will modify the database during testing. If you want to preserve your local data use a separate database.
 DB_NAME=wordpress
-# localhost creates issues with wp config create command
 DB_HOST=127.0.0.1
 # Make sure the user has the necessary permissions for the database. E.g. `GRANT ALL PRIVILEGES ON wordpress.* TO 'root'@'localhost';`
 DB_USER=root

--- a/bin/_lib.sh
+++ b/bin/_lib.sh
@@ -57,7 +57,7 @@ install_db() {
 		return 0
 	fi
 
-	local EXTRA=" --host=$WORDPRESS_DB_HOST --protocol=tcp"
+	local EXTRA=" --host=$WORDPRESS_DB_HOST"
 
 	if [ -n "$WORDPRESS_DB_PORT" ]; then
 		EXTRA="$EXTRA --port=$WORDPRESS_DB_PORT"


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

Removes the `--protocol=tcp` flag from `_lib.sh`'s `install_db()` command.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->

Causes issues with LocalWP that aren't worth debugging.

### Related Issue(s):
<!-- E.g.
- Fixes #123
- Closes #456
-->

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots
<!-- Include relevant screenshots proving the PR works as indended. -->

## Additional Info
<!-- Please include any relevant logs, error output, etc -->

## Checklist
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too. -->
- [ ] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [ ] My code is tested to the best of my abilities.
- [ ] My code passes all lints (PHPCS, PHPStan, ESLint, etc). <!-- See the Contributing Guidelines for linting instructions -->
- [ ] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
- [ ] I have updated the project documentation accordingly.
