### PR TITLE
dev : Add `snapwp_helper/env/variables` filter

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -147,7 +147,7 @@ apply_filters( 'snapwp_helper/dependencies/registered_dependencies', array $depe
 
 #### `snapwp_helper/env/variables`
 
-This filter allows you to modify the list of environment variables used for configuration in your headless application.
+This filter allows you to modify the list of environment variables used by SnapWP's frontend framework.
 
 ```php
 apply_filters( 'snapwp_helper/env/variables', array $variables );
@@ -155,11 +155,11 @@ apply_filters( 'snapwp_helper/env/variables', array $variables );
 
 ##### Parameters
 
-- `$variables` _(array<string,array{description:string,default:string,required:bool}>)_: This array contains the details of the environment variables. Each element provides the following information:
+- `$variables` _(array<string,array{description:string,default:string,required:bool}>)_: This array contains the details of the environment variables, keyed to the variable name. Each item provides the following information:
 
    - `description` _(string)_: A brief explanation of what the variable controls or configures.
    - `default` _(string)_: The default value assigned to the variable if not set explicitly.
-   - `required` _(bool)_: Indicates if this variable is mandatory for proper functionality.
+   - `required` _(bool)_: Whether the variable is mandatory for proper functionality.
 
 ### Plugin Updater
 

--- a/src/Modules/EnvGenerator/VariableRegistry.php
+++ b/src/Modules/EnvGenerator/VariableRegistry.php
@@ -14,6 +14,8 @@ class VariableRegistry {
 	/**
 	 * Array of environment variables.
 	 *
+	 * @todo Support conditional variables.
+	 *
 	 * @var array<string,array{description:string,default:string,required:bool}>
 	 */
 	private const VARIABLES = [
@@ -50,11 +52,10 @@ class VariableRegistry {
 	 * Constructor
 	 */
 	public function __construct() {
-		// @todo Allow for conditionals.
 		/**
-		 * Filters the list of environment variables used in the VariableRegistry class.
+		 * Filters the list of environment variables recognized by SnapWP.
 		 *
-		 * @param array<string,array{description:string,default:string,required:bool}> $variables The default environment variables.
+		 * @param array<string,array{description:string,default:string,required:bool}> $variables The default environment variables, keyed by name.
 		 */
 		$this->variables = (array) apply_filters( 'snapwp_helper/env/variables', self::VARIABLES );
 	}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
- Made the `VariableRegistry` env variables filterable by introducing the `apply_filters` function in the constructor to allow    customization of the environment variables.
- Updated the Hooks documentation to include the new filter hook `snapwp_helper/env/variables`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
- This PR is necessary as it makes the VariableRegistry env variables filterable to provide the flexibility to modify the default environment variables .

### Related Issue(s):
<!-- E.g.
- Fixes #123
- Closes #456
-->
_From Mega issues spreadsheet._

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
- Updated the VariableRegistry constructor to use the `apply_filters` function for the `VARIABLES` property.
- Added documentation for the new filter hook, including usage and parameters.

## Checklist
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too. -->
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc). 
- [x] My code has detailed inline documentation.
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.
