### PR TITLE
fix: handle layout CSS classes by caching `renderedHtml`

### DIFF
--- a/docs/graphql-queries.md
+++ b/docs/graphql-queries.md
@@ -50,11 +50,7 @@ query GetTemplateByUri( $uri: String! ) {
     isFrontPage
     isPostsPage
     isTermNode
-    renderedHtml # The fully rendered HTML content for the given URI
     uri
   }
 }
 ```
-
->[!WARNING]
-> `templateByUri.enqueuedScripts` currently does not return the correct data. This is a known issue in WPGraphQL core and will be fixed in a future release.

--- a/src/Modules/GraphQL/Data/ContentBlocksResolver.php
+++ b/src/Modules/GraphQL/Data/ContentBlocksResolver.php
@@ -18,21 +18,17 @@ final class ContentBlocksResolver {
 	/**
 	 * Retrieves a list of content blocks
 	 *
-	 * @param \WPGraphQL\Model\Model $node The node we are resolving.
-	 * @param array<string,mixed>    $args GraphQL query args to pass to the connection resolver.
-	 * @param string[]               $allowed_block_names The list of allowed block names to filter.
+	 * @param \WPGraphQL\Model\Model|array<string,mixed> $node The node we are resolving.
+	 * @param array<string,mixed>                        $args GraphQL query args to pass to the connection resolver.
+	 * @param string[]                                   $allowed_block_names The list of allowed block names to filter.
 	 *
-	 * @return array<string,mixed> The list of content blocks.
+	 * @return array<string,mixed> The resolved parsed blocks.
 	 */
 	public static function resolve_content_blocks( $node, $args, $allowed_block_names = [] ): array {
-
 		/**
 		 * When this filter returns a non-null value, the content blocks resolver will use that value
 		 *
-		 * @param ?array                 $content_blocks The content blocks to parse.
-		 * @param \WPGraphQL\Model\Model $node           The node we are resolving.
-		 * @param array                  $args           GraphQL query args to pass to the connection resolver.
-		 * @param array                  $allowed_block_names The list of allowed block names to filter.
+		 * @see WPGraphQL\ContentBlocks\Data\ContentBlocksResolver::resolve_content_blocks()
 		 */
 		$pre_resolved_blocks = apply_filters( 'wpgraphql_content_blocks_pre_resolve_blocks', null, $node, $args, $allowed_block_names ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WPGraphQL filter.
 
@@ -57,9 +53,7 @@ final class ContentBlocksResolver {
 		/**
 		 * Filters the content retrieved from the node used to parse the blocks.
 		 *
-		 * @param ?string                $content The content to parse.
-		 * @param \WPGraphQL\Model\Model $node    The node we are resolving.
-		 * @param array                  $args    GraphQL query args to pass to the connection resolver.
+		 * @see WPGraphQL\ContentBlocks\Data\ContentBlocksResolver::resolve_content_blocks()
 		 */
 		$content = apply_filters( 'wpgraphql_content_blocks_resolver_content', $content, $node, $args ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WPGraphQL filter.
 
@@ -84,54 +78,11 @@ final class ContentBlocksResolver {
 		/**
 		 * Filters the content blocks after they have been resolved.
 		 *
-		 * @param array                  $parsed_blocks The parsed blocks.
-		 * @param \WPGraphQL\Model\Model $node          The node we are resolving.
-		 * @param array                  $args          GraphQL query args to pass to the connection resolver.
-		 * @param array                  $allowed_block_names The list of allowed block names to filter.
+		 * @see WPGraphQL\ContentBlocks\Data\ContentBlocksResolver::resolve_content_blocks()
 		 */
 		$parsed_blocks = apply_filters( 'wpgraphql_content_blocks_resolve_blocks', $parsed_blocks, $node, $args, $allowed_block_names ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WPGraphQL filter.
 
 		return $parsed_blocks;
-	}
-
-	/**
-	 * Flattens a list blocks into a single array
-	 *
-	 * @param array<string,mixed> $blocks A list of blocks to flatten.
-	 *
-	 * @return array<string,mixed> The flattened list of blocks.
-	 */
-	private static function flatten_block_list( $blocks ): array {
-		$result = [];
-		foreach ( $blocks as $block ) {
-			$result = array_merge( $result, self::flatten_inner_blocks( $block ) );
-		}
-		return $result;
-	}
-
-	/**
-	 * Flattens a block and its inner blocks into a single while attaching unique clientId's
-	 *
-	 * @param array<string,mixed> $block A block.
-	 *
-	 * @return array<string,mixed> The flattened block.
-	 */
-	private static function flatten_inner_blocks( $block ): array {
-		$result = [];
-
-		// Assign a unique clientId to the block if it doesn't already have one.
-		$block['clientId'] = isset( $block['clientId'] ) ? $block['clientId'] : uniqid();
-		array_push( $result, $block );
-
-		foreach ( $block['innerBlocks'] as $child ) {
-			$child['parentClientId'] = $block['clientId'];
-
-			// Flatten the child, and merge with the result.
-			$result = array_merge( $result, self::flatten_inner_blocks( $child ) );
-		}
-
-		/** @var array<string,mixed> $result */
-		return $result;
 	}
 
 	/**
@@ -160,6 +111,7 @@ final class ContentBlocksResolver {
 		$parsed = [];
 		foreach ( $blocks as $block ) {
 			$block_data = self::handle_do_block( $block );
+
 			if ( $block_data ) {
 				$parsed[] = $block_data;
 			}
@@ -181,21 +133,21 @@ final class ContentBlocksResolver {
 			return null;
 		}
 
-		// Set the block name to `core/freeform` if it's empty.
-		if ( empty( $block['blockName'] ) ) {
+		// Since Gutenberg assigns an empty blockName for Classic block, we define it here.
+		if ( empty( trim( $block['blockName'] ) ) ) {
 			$block['blockName'] = 'core/freeform';
 		}
 
 		// Assign a unique clientId to the block.
 		$block['clientId'] = uniqid();
 
-		// Handle core/template-part blocks.
+		// Render the HTML once and store it for later use.
+		$block['renderedHtml'] = render_block( $block );
+
+		// @todo apply more hydrations.
 		$block = self::populate_template_part_inner_blocks( $block );
-
 		$block = self::populate_post_content_inner_blocks( $block );
-
 		$block = self::populate_reusable_blocks( $block );
-
 		$block = self::populate_pattern_inner_blocks( $block );
 
 		/**
@@ -224,12 +176,17 @@ final class ContentBlocksResolver {
 			return false;
 		}
 
-		// If there is no innerHTML or innerContent, we can consider it empty.
+		// If there is no innerHTML and no innerContent, we can consider it empty.
 		if ( empty( $block['innerHTML'] ) && empty( $block['innerContent'] ) ) {
 			return true;
 		}
 
-		$stripped = preg_replace( '/<!--(.*)-->/Uis', '', $block['innerHTML'] );
+		if ( ! array_key_exists( 'blockName', $block ) ) {
+			return true;
+		}
+
+		// Strip empty comments and spaces to see if `innerHTML` is truly empty.
+		$stripped = preg_replace( '/<!--(.*)-->|[\s\n\r]+/Uis', '', $block['innerHTML'] );
 
 		return empty( trim( $stripped ?? '' ) );
 	}
@@ -265,33 +222,6 @@ final class ContentBlocksResolver {
 	}
 
 	/**
-	 * Populates reusable blocks with the blocks from the reusable ref ID.
-	 *
-	 * @param array<string,mixed> $block The block to populate.
-	 *
-	 * @return array<string,mixed> The populated block.
-	 */
-	private static function populate_reusable_blocks( array $block ): array {
-		if ( 'core/block' !== $block['blockName'] || ! isset( $block['attrs']['ref'] ) ) {
-			return $block;
-		}
-
-		$reusable_block = get_post( $block['attrs']['ref'] );
-
-		if ( ! $reusable_block ) {
-			return $block;
-		}
-
-		$parsed_blocks = ! empty( $reusable_block->post_content ) ? self::parse_blocks( $reusable_block->post_content ) : null;
-
-		if ( empty( $parsed_blocks ) ) {
-			return $block;
-		}
-
-		return array_merge( ...$parsed_blocks );
-	}
-
-	/**
 	 * Populates the innerBlocks of a core/post-content block with the blocks from the post content.
 	 *
 	 * @param array<string,mixed> $block The block to populate.
@@ -321,6 +251,33 @@ final class ContentBlocksResolver {
 	}
 
 	/**
+	 * Populates reusable blocks with the blocks from the reusable ref ID.
+	 *
+	 * @param array<string,mixed> $block The block to populate.
+	 *
+	 * @return array<string,mixed> The populated block.
+	 */
+	private static function populate_reusable_blocks( array $block ): array {
+		if ( 'core/block' !== $block['blockName'] || ! isset( $block['attrs']['ref'] ) ) {
+			return $block;
+		}
+
+		$reusable_block = get_post( $block['attrs']['ref'] );
+
+		if ( ! $reusable_block ) {
+			return $block;
+		}
+
+		$parsed_blocks = ! empty( $reusable_block->post_content ) ? self::parse_blocks( $reusable_block->post_content ) : null;
+
+		if ( empty( $parsed_blocks ) ) {
+			return $block;
+		}
+
+		return array_merge( ...$parsed_blocks );
+	}
+
+	/**
 	 * Populates the pattern innerBlocks with the blocks from the pattern.
 	 *
 	 * @param array<string,mixed> $block The block to populate.
@@ -343,8 +300,47 @@ final class ContentBlocksResolver {
 		}
 
 		$block['innerBlocks'] = $resolved_patterns;
-
 		return $block;
+	}
+
+	/**
+	 * Flattens a list blocks into a single array
+	 *
+	 * @param array<string,mixed> $blocks A list of blocks to flatten.
+	 *
+	 * @return array<string,mixed> The flattened list of blocks.
+	 */
+	private static function flatten_block_list( $blocks ): array {
+		$result = [];
+		foreach ( $blocks as $block ) {
+			$result = array_merge( $result, self::flatten_inner_blocks( $block ) );
+		}
+		return $result;
+	}
+
+	/**
+	 * Flattens a block and its inner blocks into a single while attaching unique clientId's
+	 *
+	 * @param array<string,mixed> $block A parsed block.
+	 *
+	 * @return array<string,mixed> The flattened block.
+	 */
+	private static function flatten_inner_blocks( $block ): array {
+		$result = [];
+
+		// Assign a unique clientId to the block if it doesn't already have one.
+		$block['clientId'] = isset( $block['clientId'] ) ? $block['clientId'] : uniqid();
+		array_push( $result, $block );
+
+		foreach ( $block['innerBlocks'] as $child ) {
+			$child['parentClientId'] = $block['clientId'];
+
+			// Flatten the child, and merge with the result.
+			$result = array_merge( $result, self::flatten_inner_blocks( $child ) );
+		}
+
+		/** @var array<string,mixed> $result */
+		return $result;
 	}
 
 	/**

--- a/src/Modules/GraphQL/Data/TemplateResolver.php
+++ b/src/Modules/GraphQL/Data/TemplateResolver.php
@@ -53,7 +53,7 @@ class TemplateResolver {
 	 * @param string                     $uri              The path to be used as an identifier for the resource.
 	 * @param array<string,mixed>|string $extra_query_vars Any extra query vars to consider
 	 *
-	 * @return ?array{renderedHtml:string,uri:string} The resolved template.
+	 * @return ?array{content:?string,uri:string} The resolved template.
 	 * @throws \GraphQL\Error\UserError If the query class does not exist.
 	 */
 	public function resolve_uri( string $uri, $extra_query_vars = '' ): ?array {
@@ -117,9 +117,8 @@ class TemplateResolver {
 		$this->wp->register_globals();
 
 		return [
-			'content'      => $this->get_rendered_template(),
-			'renderedHtml' => get_the_block_template_html(),
-			'uri'          => $uri,
+			'content' => $this->get_rendered_template(),
+			'uri'     => $uri,
 		];
 	}
 
@@ -585,6 +584,8 @@ class TemplateResolver {
 	 * Gets the block template content.
 	 *
 	 * Mimics get_the_block_template_html() without the do_blocks() call, which strips the block attributes.
+	 *
+	 * @see get_the_block_template_html()
 	 */
 	protected function get_the_block_template_content(): ?string {
 		global $_wp_current_template_content, $wp_embed;

--- a/src/Modules/GraphQL/Type/WPObject/RenderedTemplate.php
+++ b/src/Modules/GraphQL/Type/WPObject/RenderedTemplate.php
@@ -46,10 +46,6 @@ final class RenderedTemplate extends AbstractObject implements TypeWithConnectio
 				'type'        => 'String',
 				'description' => __( 'The content for the template. This is the serialized block markup and HTML.', 'snapwp-helper' ),
 			],
-			'renderedHtml'  => [
-				'type'        => 'String',
-				'description' => __( 'The rendered HTML for the template.', 'snapwp-helper' ),
-			],
 			'bodyClasses'   => [
 				'type'        => [ 'list_of' => 'String' ],
 				'description' => __( 'The css classes for the HTML `<body>` tag.', 'snapwp-helper' ),

--- a/tests/Integration/EnqueuedScriptModulesTest.php
+++ b/tests/Integration/EnqueuedScriptModulesTest.php
@@ -223,7 +223,7 @@ class EnqueuedScriptModulesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestC
 
 		$post_url = get_permalink( $post_id );
 
-		$query     = $this->query();
+		$query = $this->query();
 
 		$variables = [ 'uri' => wp_make_link_relative( $post_url ) ];
 
@@ -244,7 +244,7 @@ class EnqueuedScriptModulesTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestC
 				}
 			)
 		)[0];
-	
+
 		$this->assertNotEmpty( $actual_dep['id'], 'Data should contain a valid ID' );
 		$this->assertNotEmpty( $actual_dep['extraData'], 'Data should contain a data object' );
 

--- a/tests/Integration/TemplateByUriQueryTest.php
+++ b/tests/Integration/TemplateByUriQueryTest.php
@@ -125,7 +125,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 						name
 					}
 				}
-				renderedHtml
 			}
 		}';
 	}
@@ -157,7 +156,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// 2. Test a good URI.
 		$post_link = get_permalink( $post_id );
@@ -173,7 +171,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( $expected_graphql_type, $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a ' . $expected_graphql_type );
 		$this->assertEquals( $post_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Test postByUri', $actual['data']['templateByUri']['connectedNode']['title'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Test postByUri', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the post title' );
 	}
 
 	/**
@@ -214,7 +211,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// 2. Test a valid URI for the parent page.
 		$parent_page_link = get_permalink( $parent_page_id );
@@ -231,7 +227,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( $expected_graphql_type, $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a ' . $expected_graphql_type );
 		$this->assertEquals( $parent_page_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Parent Page', $actual['data']['templateByUri']['connectedNode']['title'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Parent Page', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the parent page title' );
 
 		// 3. Test an invalid child page URI under a valid parent.
 		$variables['uri'] = wp_make_link_relative( $parent_page_link ) . '/invalid-child-page'; // This URI should not exist.
@@ -242,7 +237,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// 4. Test a valid child page URI.
 		$child_page_link = get_permalink( $child_page_id );
@@ -259,7 +253,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( $expected_graphql_type, $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a ' . $expected_graphql_type );
 		$this->assertEquals( $child_page_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Child Page', $actual['data']['templateByUri']['connectedNode']['title'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Child Page', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the child page title' );
 	}
 
 	/**
@@ -291,7 +284,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// Test a good URI.
 		$cpt_link = get_permalink( $cpt_id );
@@ -307,7 +299,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( $expected_graphql_type, $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a ' . $expected_graphql_type );
 		$this->assertEquals( $cpt_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Test cptByUri', $actual['data']['templateByUri']['connectedNode']['title'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Test cptByUri', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the page title' );
 	}
 
 	/**
@@ -339,7 +330,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// Test a good URI.
 		$category_link = get_term_link( $category_id );
@@ -354,7 +344,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( 'Category', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a Category' );
 		$this->assertEquals( $category_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Test Category', $actual['data']['templateByUri']['connectedNode']['name'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Test Category', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the category title' );
 	}
 
 	/**
@@ -386,7 +375,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// Test a good URI.
 		$tag_link = get_tag_link( $tag_id );
@@ -401,7 +389,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( 'Tag', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a Tag' );
 		$this->assertEquals( $tag_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Test Tag', $actual['data']['templateByUri']['connectedNode']['name'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Test Tag', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the tag title' );
 	}
 
 	/**
@@ -432,7 +419,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// Test a good URI.
 		$term_link = get_term_link( $term_id );
@@ -447,7 +433,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( 'CustomTax', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a CustomTax' );
 		$this->assertEquals( $term_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Test Custom Tax Term', $actual['data']['templateByUri']['connectedNode']['name'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Test Custom Tax Term', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the custom taxonomy term title' );
 	}
 
 	/**
@@ -512,7 +497,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// Test a good URI.
 		$archive_link = get_post_type_archive_link( 'non_hierarchical_cpt' );
@@ -525,7 +509,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertContains( 'post-type-archive', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the post-type-archive class' );
 		$this->assertContains( 'post-type-archive-non_hierarchical_cpt', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the post-type-archive-# class' );
 		$this->assertEquals( 'ContentType', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a CustomTypeArchive' );
-		$this->assertStringContainsString( 'Archive', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the archive content' );
 	}
 
 	/**
@@ -567,7 +550,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// Test a good URI for the parent post archive.
 		$archive_link = get_post_type_archive_link( 'hierarchical_cpt' );
@@ -580,7 +562,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertContains( 'post-type-archive', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the post-type-archive class' );
 		$this->assertContains( 'post-type-archive-hierarchical_cpt', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the post-type-archive-# class' );
 		$this->assertEquals( 'ContentType', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a CustomTypeArchive' );
-		$this->assertStringContainsString( 'Archive', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the archive content' );
 	}
 
 	/**
@@ -620,7 +601,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// Test invalid archive URIs.
 		$invalid_uris = [
@@ -636,7 +616,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 			$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 			$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 			$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-			$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 		}
 
 		// Test valid archive URIs.
@@ -653,7 +632,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 			$this->assertArrayNotHasKey( 'errors', $actual );
 			$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered date archive template' );
 			$this->assertContains( 'date', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the date class' );
-			$this->assertStringContainsString( 'Day', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the archive content' );
 		}
 	}
 
@@ -685,7 +663,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// Test valid archive URIs.
 		$archive_uris = get_month_link( 2024, 2 ); // Same month as the third post.
@@ -696,7 +673,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered date archive template' );
 		$this->assertContains( 'date', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the date class' );
-		$this->assertStringContainsString( 'Month', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the archive content' );
 	}
 
 	/**
@@ -728,7 +704,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 
 		// Test valid archive URIs.
 		$archive_uris = [
@@ -741,7 +716,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered date archive template' );
 		$this->assertContains( 'date', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the date class' );
-		$this->assertStringContainsString( 'Year', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the archive content' );
 	}
 
 	/**
@@ -776,7 +750,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
-		$this->assertStringContainsString( 'id="page-not-found"', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the Page not Found heading' );
 	}
 
 	/**
@@ -812,7 +785,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( 'User', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be an Author' );
 		$this->assertEquals( $this->user_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( get_the_author_meta( 'display_name', $this->user_id ), $actual['data']['templateByUri']['connectedNode']['name'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( get_the_author_meta( 'display_name', $this->user_id ), $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the author name' );
 	}
 
 	/**
@@ -846,7 +818,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( 'User', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be an Author' );
 		$this->assertEquals( $subscriber, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( get_the_author_meta( 'display_name', $subscriber ), $actual['data']['templateByUri']['connectedNode']['name'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( get_the_author_meta( 'display_name', $subscriber ), $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the author name' );
 
 		// Clean up: Delete the subscriber user.
 		wp_delete_user( $subscriber );
@@ -882,7 +853,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered author template' );
 		$this->assertContains( 'author', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the author class' );
 		$this->assertContains( 'author-' . $subscriber, $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the author-id-# class' );
-		$this->assertStringContainsString( get_the_author_meta( 'display_name', $subscriber ), $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the author name' );
 
 		$this->assertEmpty( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null if a user has no published posts' );
 
@@ -933,7 +903,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( 'Page', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a Page' );
 		$this->assertEquals( $home_page_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Home Page Test', $actual['data']['templateByUri']['connectedNode']['title'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Home Page Test', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the home page title' );
 
 		// Clean up: Restore the original options.
 		update_option( 'page_for_posts', $original_page_for_posts );
@@ -992,7 +961,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( 'Page', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a Page' );
 		$this->assertEquals( $front_page_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Front Page Test', $actual['data']['templateByUri']['connectedNode']['title'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Front Page Test', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the front page title' );
 
 		// Test posts archive URI.
 		$posts_page_uri = wp_make_link_relative( get_permalink( $posts_page_id ) );
@@ -1007,7 +975,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertEquals( 'Page', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a Page' );
 		$this->assertEquals( $posts_page_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Posts Archive Test', $actual['data']['templateByUri']['connectedNode']['title'], 'connectedNode should have the correct title' );
-		$this->assertStringContainsString( 'Posts Archive Test', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the posts archive title' );
 
 		// Clean up: Restore the original options.
 		update_option( 'page_on_front', $original_page_on_front );
@@ -1053,7 +1020,6 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		$this->assertContains( 'blog', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the blog class' );
 		$this->assertEquals( 'ContentType', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a PostsPage' );
 		$this->assertTrue( $actual['data']['templateByUri']['connectedNode']['isPostsPage'], 'connectedNode should be a posts page' );
-		$this->assertStringContainsString( 'Latest Post', $actual['data']['templateByUri']['renderedHtml'], 'renderedHtml should contain the title of Latest Post 1' );
 
 		// Clean up: Restore the original options.
 		update_option( 'page_on_front', $original_page_on_front );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR fixes `templateByUri` resolution to cache and preresolve all blocks, ensuring that the related block styles/scripts are enqueued in the model.

As a result, `templateByUri.renderedHtml` has been removed. You should be able to get similar results by calling `templateByUri.editorBlocks( flat: false) { renderedHtml } `. 

Some additional code cleanup and alignment with backports merged into WPGraphQL Content Blocks are included.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->

There are a confluence of codependent issues:
- WordPress handles most work on `render_block()`, however each time that's called the static identifiers (like the `*-has-layout-#` classes increment.
- Blocks need to be rendered in order for scripts/styles/etc to be hydrated correctly
- WPGraphQL Content Blocks (ab)uses `render_block()` in the field `resolve`r, leading it to:
   1. be called thousands of times
   2. be called _after_ the scripts/styles/scriptModules/etc are resolved.

### Related Issue(s):
<!-- E.g.
- Fixes #123
- Closes #456
-->

Fixes https://github.com/rtCamp/headless/issues/234

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->

We modify `ContentBlocksResolver` to store the `render_block()` results on the block, and then call it when setting up our `ResolvedTemplate` model.

While this means we need to hold on to our `ContentBlocksResolver` shim a little longer, it allows us to go live without waiting on WPGraphQL Content Blocks to make what would be for them a breaking change.

> [!IMPORTANT]
> This approach does not result in _identical css class IDs_ between traditional and headless WP.
>
> Rather, it ensures that all the CSS classes are caught by the WP Style Engine, and caching keeps the number of duplicate styles (and calls to `render_block()` down to a "reasonable" amount.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Use https://github.com/rtCamp/snapwp/pull/5 to test
2. Ensure the visuals match with traditional wordpress.

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->
![image](https://github.com/user-attachments/assets/c3e60918-c4b8-450a-91f1-acdb02c1235b)

(Note the matching style is printed, albeit several times)

## Additional Info
<!-- Please include any relevant logs, error output, etc -->

## Checklist
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too. -->
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.
