### PR TITLE
fix: update references to point to `rtcamp/snapwp` monorepo

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ Manages WPGraphQL extensions updates and discover.
 
 == Description ==
 
-A helper plugin used to power <a href="https://github.com/rtCamp/headless/ target="_blank">SnapWP</a>.
+A helper plugin used to power <a href="https://github.com/rtCamp/snapwp/ target="_blank">SnapWP</a>.
 
 For more info, see the <a href="https://github.com/rtCamp/snapwp-helper">SnapWP Helper GitHub repository</a>.
 
@@ -41,4 +41,4 @@ Once you're ready to send a pull request, please check out our <a href="https://
 
 == Changelog ==
 
-See the full list of changes in the <a href="https://github.com/rtcamp/headless/blob/main/wp/snapwp-helper/CHANGELOG.md" target="_blank">repository Changelog</a>.
+See the full list of changes in the <a href="https://github.com/rtCamp/snapwp-helper/blob/develop/CHANGELOG.md" target="_blank">repository Changelog</a>.


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->
## What
Update repository references in `snapwp-helper` from `rtcamp/headless` to `rtcamp/snapwp`

## Why
Align with the new monorepo structure where the package has been moved to `rtcamp/snapwp`

### Related Issue(s):
<!-- No related issues -->

## How
- Search and replace repository URLs in `snapwp-helper` package
- Update from `https://github.com/rtCamp/headless/` to `https://github.com/rtCamp/snapwp/`
- Update any related documentation references

## Testing Instructions
1. Check all repository links in the codebase point to the new location
2. Verify package dependencies and references resolve correctly
3. Ensure no broken links remain

## Screenshots
<!-- Not applicable for this change -->

## Additional Info
This is a straightforward repository reference update with no functional changes.

## Checklist
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.).
- [x] My code has detailed inline documentation.
- [ ] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.