### PR TITLE
fix: Remove `remove_actions()` workaround.

### DIFF
--- a/tests/Integration/DependenciesTest.php
+++ b/tests/Integration/DependenciesTest.php
@@ -93,9 +93,6 @@ class DependenciesTest extends WPTestCase {
 		// Check that the admin notice is displayed.
 		Dependencies::instance()->check_and_display_admin_notice();
 
-		// Remove conflicting actions from wp-graphql-content-blocks
-		$this->remove_actions();
-
 		ob_start();
 		do_action( 'admin_notices' );
 
@@ -167,19 +164,5 @@ class DependenciesTest extends WPTestCase {
 		$instance   = $reflection->getProperty( 'instance' );
 		$instance->setAccessible( true );
 		$instance->setValue( null );
-	}
-
-	/**
-	 * Remove broken actions from wp-graphql-content-blocks.
-	 *
-	 * @see https://github.com/wpengine/wp-graphql-content-blocks/pull/262
-	 *
-	 * @todo remove once PR is merged.
-	 */
-	protected function remove_actions(): void {
-		$namespace = 'WPGraphQL\ContentBlocks\PluginUpdater';
-
-		remove_action( 'admin_notices', $namespace . '\delegate_plugin_row_notice' );
-		remove_action( 'admin_notices', $namespace . '\display_update_page_notice' );
 	}
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
Remove temporary workaround for wp-graphql-content-blocks plugin conflicts

## Why
The workaround is no longer needed as the underlying issue has been fixed in wp-graphql-content-blocks PR #262

### Related Issue(s):
Part of https://github.com/rtCamp/headless/issues/303 ([Task sheet](https://docs.google.com/spreadsheets/d/1KWqqO8h-T95WcIacNsE1OXgvdTNF70XeNJXmKs-ZhAI/edit?gid=2136963320#gid=2136963320))

## How
- Removed `remove_actions()` method and its docblock
- Removed call to `$this->remove_actions()` in `testRequireAutoloader()`

## Testing Instructions
1. Run PHPUnit tests
2. Verify all tests pass without errors

## Screenshots
N/A

## Additional Info
N/A

## Checklist
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.).
- [x] My code has detailed inline documentation.
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.