### PR TITLE
fix: use `manage_options` for admin screen permissions

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -21,6 +21,8 @@
      - [`snapwp_helper/env/variables`](#snapwp_helperenvvariables)
    - [Plugin Updater](#plugin-updater)
      - [`snapwp_helper/plugin_updater/plugins`](#snapwp_helperplugin_updaterplugins)
+  - [Admin Screen](#admin-screen)
+    - [`snapwp_helper/admin/capability`](#snapwp_helperadmincapability)
 
 ## Action Hooks
 
@@ -140,8 +142,8 @@ apply_filters( 'snapwp_helper/dependencies/registered_dependencies', array $depe
 
 - `$dependencies` _(array)_: An array of dependencies. Each element in the array is an associative array with the following keys
    - `slug` _(string)_: A unique slug to identify the dependency. E.g. Plugin slug.
-	 - `name` _(string)_: The pretty name of the dependency used in the admin notice.
-	 - `check_callback` _(`callable(): true|\WP_Error`)_: A callable that returns true if the dependency is met, or a `WP_Error` object (with an explicit error message) if the dependency is not met.
+   - `name` _(string)_: The pretty name of the dependency used in the admin notice.
+   - `check_callback` _(`callable(): true|\WP_Error`)_: A callable that returns true if the dependency is met, or a `WP_Error` object (with an explicit error message) if the dependency is not met.
 
 ### Environment Variables
 
@@ -177,3 +179,17 @@ apply_filters( 'snapwp_helper/plugin_updater/plugins', array $plugins );
 
    - `slug` _(string)_: The qualified plugin slug with its folder. E.g. 'wp-graphql-my-plugin/wp-graphql-my-plugin.php'.
    - `update_uri` _(string)_: The URI used to check for plugin updates.
+
+### Admin Screen
+
+#### `snapwp_helper/admin/capability`
+
+Filters the capability required to access the SnapWP Helper admin screen and make any dashboard-related changes.
+
+```php
+apply_filters( 'snapwp_helper/admin/capability', string $capability );
+```
+
+##### Parameters
+
+- `$capability` _(string)_: The capability required to access the SnapWP Helper admin screen and make any dashboard-related changes. Default is `manage_options`.

--- a/src/Modules/Admin.php
+++ b/src/Modules/Admin.php
@@ -18,6 +18,15 @@ use SnapWP\Helper\Modules\GraphQL\Data\IntrospectionToken;
  */
 class Admin implements Module {
 	/**
+	 * The capability required to access the SnapWP Helper screen and do admin-related actions.
+	 *
+	 * Filtered by `snapwp_helper/admin/capability`.
+	 *
+	 * @var ?string
+	 */
+	private ?string $capability;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function name(): string {
@@ -48,6 +57,7 @@ class Admin implements Module {
 		 * @see https://github.com/wp-graphql/wpgraphql-ide/issues/214
 		 */
 		add_action( 'admin_menu', [ $this, 'register_menu' ], 101 );
+		add_action( 'current_screen', [ $this, 'handle_token_regeneration' ] );
 	}
 
 	/**
@@ -64,13 +74,11 @@ class Admin implements Module {
 			$parent_menu_slug,
 			__( 'SnapWP', 'snapwp-helper' ),
 			__( 'SnapWP', 'snapwp-helper' ),
-			'edit_plugins',
+			$this->get_capability(), // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- It's user filterable.
 			'snapwp-helper',
 			[ $this, 'render_menu' ],
 			999
 		);
-
-		add_action( 'current_screen', [ $this, 'handle_token_regeneration' ] );
 	}
 
 	/**
@@ -230,6 +238,16 @@ class Admin implements Module {
 			return;
 		}
 
+		if ( ! current_user_can( $this->get_capability() ) ) { // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- It's user filterable.
+			wp_admin_notice(
+				__( 'Could not regenerate the introspection token: insufficient permissions.', 'snapwp-helper' ),
+				[
+					'type' => 'error',
+				]
+			);
+			return;
+		}
+
 		// Generate a new introspection token.
 		$introspection_token = IntrospectionToken::generate_token();
 
@@ -254,5 +272,25 @@ class Admin implements Module {
 				'type' => 'success',
 			]
 		);
+	}
+
+	/**
+	 * Get the capability required to access the SnapWP Helper screen and do admin-related actions.
+	 *
+	 * @uses snapwp_helper/admin/capability filter
+	 */
+	private function get_capability(): string {
+		if ( ! isset( $this->capability ) ) {
+			/**
+			 * Filter the capability required to access the SnapWP Helper admin screen and do admin-related actions.
+			 *
+			 * Defaults to `manage_options`.
+			 *
+			 * @param string $capability The capability required to access the SnapWP Helper admin screen and do admin-related actions.
+			 */
+			$this->capability = apply_filters( 'snapwp_helper/admin/capability', 'manage_options' );
+		}
+
+		return $this->capability;
 	}
 }

--- a/tests/Acceptance/AdminMenuCest.php
+++ b/tests/Acceptance/AdminMenuCest.php
@@ -6,15 +6,14 @@ use AcceptanceTester;
 
 class AdminMenuCest {
 	/**
-	 * Tests that the plugin can be activated and deactivated correctly.
+	 * Tests that the SnapWP Helper is added to the admin menu.
 	 */
 	public function test_submenu_location( AcceptanceTester $I ): void {
-
 		// Deactivate all plugins in the db:
 		$I->updateInDatabase(
-				'wp_options',
-				[ 'option_value' => 'a:0:{}' ],
-				[ 'option_name' => 'active_plugins' ]
+			'wp_options',
+			[ 'option_value' => 'a:0:{}' ],
+			[ 'option_name' => 'active_plugins' ]
 		);
 
 		$I->loginAsAdmin();
@@ -30,7 +29,7 @@ class AdminMenuCest {
 		// This is necessary because the plugin for some reason fails with $I->activatePlugin().
 		$active_plugins = $I->grabFromDatabase( 'wp_options', 'option_value', [ 'option_name' => 'active_plugins' ] );
 
-		$active_plugins = unserialize( $active_plugins );
+		$active_plugins   = unserialize( $active_plugins );
 		$active_plugins[] = 'wp-graphql/wp-graphql.php';
 
 		$I->updateInDatabase(
@@ -38,12 +37,82 @@ class AdminMenuCest {
 			[ 'option_value' => serialize( $active_plugins ) ],
 			[ 'option_name' => 'active_plugins' ]
 		);
-		
+
 		$I->amOnPluginsPage();
 		$I->seePluginActivated( 'wp-graphql' );
 
-		// Submenu should be under WPGraphQL
+		// Submenu should be under WPGraphQL.
 		$I->seeElement( 'a', [ 'href' => 'admin.php?page=snapwp-helper' ] );
 		$I->amOnAdminPage( 'admin.php?page=snapwp-helper' );
+		$I->dontSee( 'Sorry, you are not allowed to access this page.' );
+	}
+
+	/**
+	 * Tests that the menu is not added when the user does not have the required capability.
+	 */
+	public function test_no_menu_for_non_admins( AcceptanceTester $I ): void {
+		$user_id = $I->haveUserInDatabase( 'no_manage_options', 'editor', [ 'user_pass' => 'pass' ] );
+		$I->haveUserCapabilitiesInDatabase(
+			$user_id,
+			[
+				'manage_options'   => false,
+				'activate_plugins' => true,
+			]
+		);
+		$I->loginAs( 'no_manage_options', 'pass' );
+
+		// Deactivate all plugins in the db.
+		$I->updateInDatabase(
+			'wp_options',
+			[ 'option_value' => 'a:0:{}' ],
+			[ 'option_name' => 'active_plugins' ]
+		);
+
+		$I->amOnPluginsPage();
+		$I->activatePlugin( 'snapwp-helper' );
+		$I->seePluginActivated( 'snapwp-helper' );
+
+		$I->dontSeeElement( 'a', [ 'href' => 'tools.php?page=snapwp-helper' ] );
+		$I->dontSeeElement( 'a', [ 'href' => 'admin.php?page=snapwp-helper' ] );
+
+		// Manually activate WPGraphQL
+		// This is necessary because the plugin for some reason fails with $I->activatePlugin().
+		$active_plugins = $I->grabFromDatabase( 'wp_options', 'option_value', [ 'option_name' => 'active_plugins' ] );
+
+		$active_plugins   = unserialize( $active_plugins );
+		$active_plugins[] = 'wp-graphql/wp-graphql.php';
+
+		$I->updateInDatabase(
+			'wp_options',
+			[ 'option_value' => serialize( $active_plugins ) ],
+			[ 'option_name' => 'active_plugins' ]
+		);
+
+		$I->amOnPluginsPage();
+		$I->seePluginActivated( 'wp-graphql' );
+
+		$I->dontSeeElement( 'a', [ 'href' => 'tools.php?page=snapwp-helper' ] );
+		$I->dontSeeElement( 'a', [ 'href' => 'admin.php?page=snapwp-helper' ] );
+
+		// Confirm that the user cannot access the page directly.
+		$I->amOnAdminPage( 'tools.php?page=snapwp-helper' );
+		$I->see( 'Sorry, you are not allowed to access this page.' );
+
+		$I->amOnAdminPage( 'admin.php?page=snapwp-helper' );
+		$I->see( 'Sorry, you are not allowed to access this page.' );
+
+		// Confirm that an admin can access the page.
+		$I->haveUserCapabilitiesInDatabase(
+			$user_id,
+			[
+				'manage_options'   => true,
+				'activate_plugins' => true,
+			]
+		);
+		$I->amOnPluginsPage();
+		$I->seeElement( 'a', [ 'href' => 'admin.php?page=snapwp-helper' ] );
+		$I->amOnAdminPage( 'admin.php?page=snapwp-helper' );
+
+		$I->dontSee( 'Sorry, you are not allowed to access this page.' );
 	}
 }


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR:
1. Changes the permissions used by the admin screen to `manage_options`.
2. Adds that permissions check when trying to regenerate the introspection token.
3. Adds a `snapwp_helper/admin/capability` filter for changing what capability is used.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->

Prevents issues on hosts like VIP where plugin permissions might be locked down.

H/t @aryanjasala 

### Related Issue(s):
<!-- E.g.
- Fixes #123
- Closes #456
-->

Part of https://github.com/rtCamp/headless/issues/395#issuecomment-2647348312

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->

## Additional Info
<!-- Please include any relevant logs, error output, etc -->

## Checklist
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too. -->
- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation accordingly.
