### PR TITLE
chore!: bump WPGraphQL Content Blocks to v4.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SnapWP Helper is a WordPress plugin that allows you to quickly install WPGraphQL
 - **PHP** 7.4 or higher
 - **WordPress** 6.7 or higher
 - **WPGraphQL** 1.28.0 or higher
-- **WPGraphQL Content Blocks** 4.4.0 or higher
+- **WPGraphQL Content Blocks** 4.6.0 or higher
 
 ## Getting Started
 

--- a/src/Modules/GraphQL.php
+++ b/src/Modules/GraphQL.php
@@ -122,7 +122,7 @@ class GraphQL implements Module {
 	 * @return array{slug:string,name:string,check_callback:callable():(true|\WP_Error)}
 	 */
 	protected function get_wpgraphql_content_blocks_dependency_args(): array {
-		$minimum_version = '4.4.0';
+		$minimum_version = '4.6.0';
 
 		return [
 			'slug'           => 'wp-graphql-content-blocks',

--- a/src/Modules/GraphQL/Data/ContentBlocksResolver.php
+++ b/src/Modules/GraphQL/Data/ContentBlocksResolver.php
@@ -150,13 +150,7 @@ final class ContentBlocksResolver {
 		$block = self::populate_reusable_blocks( $block );
 		$block = self::populate_pattern_inner_blocks( $block );
 
-		/**
-		 * Filters the block data after it has been processed.
-		 *
-		 * @param array<string,mixed> $block The block data.
-		 */
-		$block = apply_filters( 'wpgraphql_content_blocks_handle_do_block', $block ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WPGraphQL filter.
-
+		// @todo evaluate populate_navigation_blocks().
 		// Prepare innerBlocks.
 		if ( ! empty( $block['innerBlocks'] ) ) {
 			$block['innerBlocks'] = self::handle_do_blocks( $block['innerBlocks'] );

--- a/src/Modules/PluginUpdater.php
+++ b/src/Modules/PluginUpdater.php
@@ -29,6 +29,11 @@ class PluginUpdater implements Module {
 	private function get_plugins(): array {
 		$plugins = [
 			[
+				'slug'       => 'snapwp-helper',
+				'file_path'  => 'snapwp-helper/snapwp-helper.php',
+				'update_uri' => 'https://github.com/rtCamp/snapwp-helper',
+			],
+			[
 				'slug'       => 'wpgraphql-ide',
 				'file_path'  => 'wpgraphql-ide/wpgraphql-ide.php',
 				'update_uri' => 'https://github.com/wp-graphql/wpgraphql-ide',

--- a/src/Modules/PluginUpdater.php
+++ b/src/Modules/PluginUpdater.php
@@ -29,11 +29,6 @@ class PluginUpdater implements Module {
 	private function get_plugins(): array {
 		$plugins = [
 			[
-				'slug'       => 'wp-graphql-content-blocks',
-				'file_path'  => 'wp-graphql-content-blocks/wp-graphql-content-blocks.php',
-				'update_uri' => 'https://github.com/wpengine/wp-graphql-content-blocks',
-			],
-			[
 				'slug'       => 'wpgraphql-ide',
 				'file_path'  => 'wpgraphql-ide/wpgraphql-ide.php',
 				'update_uri' => 'https://github.com/wp-graphql/wpgraphql-ide',

--- a/tests/Integration/UpdateCheckerTest.php
+++ b/tests/Integration/UpdateCheckerTest.php
@@ -3,6 +3,8 @@
  * Tests the UpdateChecker class.
  *
  * @package SnapWP\Helper\Tests\Integration
+ *
+ * @todo update tests to use something other than wp-graphql-content-blocks.
  */
 
 namespace SnapWP\Helper\Tests\Integration;


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR bumps the minimum version of WPGraphQL Content Blocks to v4.6.0 and removes it from the PUC array.

Additionally added `snapwp-helper` to the updater.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->

v4.6. fixes their built-in update checker: https://github.com/wpengine/wp-graphql-content-blocks/pull/341

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of #456
-->


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->



## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->



## Additional Info
<!-- Please include any relevant logs, error output, etc -->



## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp-helper/blob/develop/.github/CONTRIBUTING.md
-->

- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation as needed.
- [x] I have added a changelog entry for my changes to `CHANGELOG.md`.
