### PR TITLE
fix: ensure `WPGraphQL` exists before loading in SchemaFilters 

### DIFF
--- a/snapwp-helper.php
+++ b/snapwp-helper.php
@@ -32,12 +32,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Load the autoloader.
-require_once __DIR__ . '/src/Autoloader.php';
-if ( ! \SnapWP\Helper\Autoloader::autoload() ) {
-	return;
-}
-
 /**
  * Define the plugin constants.
  */
@@ -79,15 +73,63 @@ function constants(): void {
 	}
 }
 
-// Run this function when the plugin is activated.
-if ( file_exists( __DIR__ . '/activation.php' ) ) {
-	require_once __DIR__ . '/activation.php';
-	register_activation_hook( __FILE__, 'SnapWP\Helper\activation_callback' );
+// Check for dependencies.
+add_action( 'plugins_loaded', __NAMESPACE__ . '\check_dependencies' );
+
+/**
+ * Check if required plugins are installed and activated.
+ */
+function check_dependencies(): void {
+	// Get the list of active plugins.
+	$active_plugins = get_option( 'active_plugins' );
+
+	// Required plugins.
+	$required_plugins = [
+		'wp-graphql/wp-graphql.php' => 'https://wordpress.org/plugins/wp-graphql/',
+		'wp-graphql-content-blocks/wp-graphql-content-blocks.php' => 'https://github.com/wp-graphql/wp-graphql-content-blocks',
+	];
+
+	// Check if required plugin are installed and activated.
+	foreach ( $required_plugins as $slug => $url ) {
+		if ( ! in_array( $slug, $active_plugins, true ) ) {
+			add_action(
+				'admin_notices',
+				static function () use ( $slug, $url ) {
+					$slug_name = explode( '\\', $slug );
+					$slug_name = end( $slug_name );
+					echo '<div class="notice notice-error"><p><strong>SnapWP Helper:</strong> ' . esc_html( $slug_name ) . ' is not installed or activated. Please install and activate <a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $slug_name ) . '</a> to use this plugin.</p></div>';
+				}
+			);
+
+			// Bail early.
+			return;
+		}
+	}
+
+	// Load the plugin if dependencies are met.
+	plugin_init();
 }
 
-// Load the plugin.
-if ( class_exists( 'SnapWP\Helper\Main' ) ) {
-	constants();
+/**
+ * Initialize the plugin.
+ */
+function plugin_init(): void {
+	// Load the autoloader.
+	require_once __DIR__ . '/src/Autoloader.php';
+	if ( ! \SnapWP\Helper\Autoloader::autoload() ) {
+		return;
+	}
 
-	\SnapWP\Helper\Main::instance();
+	// Run activation callback if file exists.
+	if ( file_exists( __DIR__ . '/activation.php' ) ) {
+		require_once __DIR__ . '/activation.php';
+		register_activation_hook( __FILE__, __NAMESPACE__ . '\activation_callback' );
+	}
+
+	// Load the plugin.
+	if ( class_exists( 'SnapWP\Helper\Main' ) ) {
+		constants();
+
+		\SnapWP\Helper\Main::instance();
+	}
 }

--- a/src/Modules/GraphQL.php
+++ b/src/Modules/GraphQL.php
@@ -49,7 +49,11 @@ class GraphQL implements Module {
 
 		foreach ( $classes_to_register as $class ) {
 			$class_instance = new $class();
-			$class_instance->register_hooks();
+
+			// Check if WPGraphQL class exists before registering hooks.
+			if ( class_exists( 'WPGraphQL' ) ) {
+				$class_instance->register_hooks();
+			}
 		}
 
 		// We only want to register our types After WPGraphQL has been initialized.

--- a/src/Modules/GraphQL.php
+++ b/src/Modules/GraphQL.php
@@ -31,7 +31,8 @@ class GraphQL implements Module {
 	public function init(): void {
 		$this->register_dependencies();
 
-		$this->register_hooks();
+		// This is deferred to give the dependencies a chance to load.
+		add_action( 'snapwp_helper/init', [ $this, 'register_hooks' ] );
 	}
 
 	/**
@@ -49,11 +50,7 @@ class GraphQL implements Module {
 
 		foreach ( $classes_to_register as $class ) {
 			$class_instance = new $class();
-
-			// Check if WPGraphQL class exists before registering hooks.
-			if ( class_exists( 'WPGraphQL' ) ) {
-				$class_instance->register_hooks();
-			}
+			$class_instance->register_hooks();
 		}
 
 		// We only want to register our types After WPGraphQL has been initialized.

--- a/src/Modules/GraphQL/SchemaFilters.php
+++ b/src/Modules/GraphQL/SchemaFilters.php
@@ -98,7 +98,7 @@ final class SchemaFilters implements Registrable {
 	 */
 	public function overload_content_blocks_resolver( array $fields, $typename ): array {
 		// Bail if WPGraphQL is not loaded.
-		if( ! class_exists('WPGraphQL') ){
+		if ( ! class_exists( 'WPGraphQL' ) ) {
 			return $fields;
 		}
 
@@ -154,7 +154,7 @@ final class SchemaFilters implements Registrable {
 	 */
 	public function get_cached_rendered_block( $block_content, $parsed_block ) {
 		// Bail if not a GraphQL request.
-		if ( ! class_exists('WPGraphQL') || ! WPGraphQL::is_graphql_request() ) {
+		if ( ! class_exists( 'WPGraphQL' ) || ! \WPGraphQL::is_graphql_request() ) {
 			return $block_content;
 		}
 
@@ -187,7 +187,7 @@ final class SchemaFilters implements Registrable {
 	 */
 	public function cache_rendered_block( $block_content, $parsed_block ) {
 		// Bail if not a GraphQL request.
-		if ( ! class_exists('WPGraphQL') || ! WPGraphQL::is_graphql_request() ) {
+		if ( ! class_exists( 'WPGraphQL' ) || ! \WPGraphQL::is_graphql_request() ) {
 			return $block_content;
 		}
 

--- a/src/Modules/GraphQL/SchemaFilters.php
+++ b/src/Modules/GraphQL/SchemaFilters.php
@@ -13,7 +13,6 @@ use SnapWP\Helper\Interfaces\Registrable;
 use SnapWP\Helper\Modules\GraphQL\Data\ContentBlocksResolver;
 use SnapWP\Helper\Modules\GraphQL\Server\DisableIntrospectionRule;
 use SnapWP\Helper\Modules\GraphQL\Type\WPObject\RenderedTemplate;
-use WPGraphQL;
 
 /**
  * Class - SchemaFilters
@@ -39,6 +38,11 @@ final class SchemaFilters implements Registrable {
 	 * There's need to check for dependencies, since missing filters will just be ignored.
 	 */
 	public function register_hooks(): void {
+		// Register hooks only if WPGraphQL exists.
+		if ( ! class_exists( 'WPGraphQL' ) ) {
+			return;
+		}
+
 		// Register custom validation rule for introspection.
 		add_filter( 'graphql_validation_rules', [ $this, 'add_custom_validation_rule' ] );
 
@@ -93,6 +97,11 @@ final class SchemaFilters implements Registrable {
 	 * @return array<string,mixed>
 	 */
 	public function overload_content_blocks_resolver( array $fields, $typename ): array {
+		// Bail if WPGraphQL is not loaded.
+		if( ! class_exists('WPGraphQL') ){
+			return $fields;
+		}
+
 		if ( ! isset( $fields['editorBlocks'] ) ) {
 			return $fields;
 		}
@@ -145,7 +154,7 @@ final class SchemaFilters implements Registrable {
 	 */
 	public function get_cached_rendered_block( $block_content, $parsed_block ) {
 		// Bail if not a GraphQL request.
-		if ( ! WPGraphQL::is_graphql_request() ) {
+		if ( ! class_exists('WPGraphQL') || ! WPGraphQL::is_graphql_request() ) {
 			return $block_content;
 		}
 
@@ -178,7 +187,7 @@ final class SchemaFilters implements Registrable {
 	 */
 	public function cache_rendered_block( $block_content, $parsed_block ) {
 		// Bail if not a GraphQL request.
-		if ( ! WPGraphQL::is_graphql_request() ) {
+		if ( ! class_exists('WPGraphQL') || ! WPGraphQL::is_graphql_request() ) {
 			return $block_content;
 		}
 

--- a/src/Modules/GraphQL/SchemaFilters.php
+++ b/src/Modules/GraphQL/SchemaFilters.php
@@ -38,11 +38,6 @@ final class SchemaFilters implements Registrable {
 	 * There's need to check for dependencies, since missing filters will just be ignored.
 	 */
 	public function register_hooks(): void {
-		// Register hooks only if WPGraphQL exists.
-		if ( ! class_exists( 'WPGraphQL' ) ) {
-			return;
-		}
-
 		// Register custom validation rule for introspection.
 		add_filter( 'graphql_validation_rules', [ $this, 'add_custom_validation_rule' ] );
 
@@ -97,11 +92,6 @@ final class SchemaFilters implements Registrable {
 	 * @return array<string,mixed>
 	 */
 	public function overload_content_blocks_resolver( array $fields, $typename ): array {
-		// Bail if WPGraphQL is not loaded.
-		if ( ! class_exists( 'WPGraphQL' ) ) {
-			return $fields;
-		}
-
 		if ( ! isset( $fields['editorBlocks'] ) ) {
 			return $fields;
 		}


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->

This PR wraps the `WPGraphQL::register_hooks()` call in our `snapwp_helper/init` action.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
The existing implementation caused fatal errors in the frontend when the `WPGraphQL` plugin was deactivated, as the class was being loaded unconditionally by our `snapwp-helper` plugin.

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of #456
-->
- Fixes [https://github.com/orgs/rtCamp/projects/141/views/10?pane=issue&itemId=97491898](https://github.com/orgs/rtCamp/projects/141/views/10?pane=issue&itemId=97491898)


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->

Since the `Main()` class only initializing dependencies after Modules themselves are `init()`ialized, by deferring `register_hooks()` to the end of our load, the `::is_dependency_met()` class can be used whenever.




## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Activate all required plugins and observe that the frontend is loading properly.
2. Before applying this PR, on deactivating the `WPGraphQL` and `WPGraphQL-Content Blocks` plugins, frontend shows a critical error.
3. After applying this PR, on deactivating the `WPGraphQL` and `WPGraphQL-Content Blocks` plugins, frontend no more shows any errors and stops site from crashing.

## Screenshots

### [ EXISITING CODE ]
#### When only `SnapWP Helper` is activated
<img width="1280" alt="Screenshot 2025-02-18 at 1 29 55 AM" src="https://github.com/user-attachments/assets/3a23ecbc-a7fc-4d02-9595-5040041f5137" />

#### [ THIS PR ] Case : When all plugins are active.
<img width="1280" alt="Screenshot 2025-02-18 at 1 24 35 AM" src="https://github.com/user-attachments/assets/7f93d1c3-4400-460c-b8e7-f255bfe86c42" />

#### [ THIS PR ] Case : When `WPGraphQL Content Blocks` is deactivated and frontend is reloaded.

<img width="1280" alt="Screenshot 2025-02-18 at 1 26 02 AM" src="https://github.com/user-attachments/assets/e7e94c83-9d51-433b-84c8-0f25a800035c" />

#### [ THIS PR ] Case : When `WPGraphQL` is also deactivated and frontend is reloaded.
<img width="1280" alt="Screenshot 2025-02-18 at 1 26 44 AM" src="https://github.com/user-attachments/assets/433582d1-02e4-41a4-a4c7-3e2d28b309a1" />



## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp-helper/blob/develop/.github/CONTRIBUTING.md
-->

- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation as needed.
- [x] I have added a changelog entry for my changes to `CHANGELOG.md`.
