### PR TITLE
fix: Ensure `templateByUri.editorBlocks` respects the `flat` query arg.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@ and this project adheres to [Semantic Versioning](./README.md#updating-and-versi
 
 ## [Unreleased]
 
-### Fixed
-- Fix : `templateByUri.editorBlocks` to respect `flat: false`.
+- fix: Ensure `templateByUri.editorBlocks` respects the `flat` query arg.
 
 ## [0.1.0] - 2025-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](./README.md#updating-and-versi
 
 ## [Unreleased]
 
+### Fixed
+- Fix : `templateByUri.editorBlocks` to respect `flat: false`.
+
 ## [0.1.0] - 2025-02-19
 
 This release represents the first 0.X release of SnapWP Helper, allowing for future _patch_ releases to be semantically versioned without breaking changes.

--- a/src/Modules/GraphQL/Data/ContentBlocksResolver.php
+++ b/src/Modules/GraphQL/Data/ContentBlocksResolver.php
@@ -67,6 +67,8 @@ final class ContentBlocksResolver {
 			return [];
 		}
 
+		$args['flat'] = 'false';
+
 		// Flatten block list here if requested or if 'flat' value is not selected (default).
 		if ( ! isset( $args['flat'] ) || 'true' == $args['flat'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 			$parsed_blocks = self::flatten_block_list( $parsed_blocks );

--- a/src/Modules/GraphQL/Data/ContentBlocksResolver.php
+++ b/src/Modules/GraphQL/Data/ContentBlocksResolver.php
@@ -67,8 +67,6 @@ final class ContentBlocksResolver {
 			return [];
 		}
 
-		$args['flat'] = 'false';
-
 		// Flatten block list here if requested or if 'flat' value is not selected (default).
 		if ( ! isset( $args['flat'] ) || 'true' == $args['flat'] ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 			$parsed_blocks = self::flatten_block_list( $parsed_blocks );

--- a/src/Modules/GraphQL/Data/ContentBlocksResolver.php
+++ b/src/Modules/GraphQL/Data/ContentBlocksResolver.php
@@ -304,7 +304,7 @@ final class ContentBlocksResolver {
 	 *
 	 * @return array<string,mixed> The flattened list of blocks.
 	 */
-	private static function flatten_block_list( $blocks ): array {
+	public static function flatten_block_list( $blocks ): array {
 		$result = [];
 		foreach ( $blocks as $block ) {
 			$result = array_merge( $result, self::flatten_inner_blocks( $block ) );

--- a/src/Modules/GraphQL/Model/RenderedTemplate.php
+++ b/src/Modules/GraphQL/Model/RenderedTemplate.php
@@ -172,6 +172,7 @@ class RenderedTemplate extends Model {
 		) {
 			while ( have_posts() ) {
 				the_post();
+
 				$blocks = ContentBlocksResolver::resolve_content_blocks(
 					$this->data,
 					[

--- a/src/Modules/GraphQL/Model/RenderedTemplate.php
+++ b/src/Modules/GraphQL/Model/RenderedTemplate.php
@@ -172,10 +172,20 @@ class RenderedTemplate extends Model {
 		) {
 			while ( have_posts() ) {
 				the_post();
-				$blocks = ContentBlocksResolver::resolve_content_blocks( $this->data, [] );
+				$blocks = ContentBlocksResolver::resolve_content_blocks(
+					$this->data,
+					[
+						'flat' => false,
+					]
+				);
 			}
 		} else {
-			$blocks = ContentBlocksResolver::resolve_content_blocks( $this->data, [] );
+			$blocks = ContentBlocksResolver::resolve_content_blocks(
+				$this->data,
+				[
+					'flat' => false,
+				]
+			);
 		}
 
 		return $blocks;

--- a/src/Modules/GraphQL/SchemaFilters.php
+++ b/src/Modules/GraphQL/SchemaFilters.php
@@ -98,7 +98,10 @@ final class SchemaFilters implements Registrable {
 
 		// RenderedTemplate is a special case, as it already has the blocks resolved.
 		if ( RenderedTemplate::get_type_name() === $typename ) {
-			$fields['editorBlocks']['resolve'] = static function ( $node ) {
+			$fields['editorBlocks']['resolve'] = static function ( $node, $args ) {
+				if ( $args['flat'] ) {
+					return ContentBlocksResolver::flatten_block_list( $node->parsed_blocks );
+				}
 				return $node->parsed_blocks;
 			};
 

--- a/src/Modules/GraphQL/SchemaFilters.php
+++ b/src/Modules/GraphQL/SchemaFilters.php
@@ -99,11 +99,12 @@ final class SchemaFilters implements Registrable {
 		// RenderedTemplate is a special case, as it already has the blocks resolved.
 		if ( RenderedTemplate::get_type_name() === $typename ) {
 			$fields['editorBlocks']['resolve'] = static function ( $node, $args ) {
-				if ( ! empty( $args['flat'] ) ) {
-					return ContentBlocksResolver::flatten_block_list( $node->parsed_blocks );
+				// Since blocks are preresolved by `templatebyUri`, may need to flatten them.
+				if ( empty( $args['flat'] ) ) {
+					return $node->parsed_blocks;
 				}
 
-				return $node->parsed_blocks;
+				return ContentBlocksResolver::flatten_block_list( $node->parsed_blocks );
 			};
 
 			return $fields;

--- a/src/Modules/GraphQL/SchemaFilters.php
+++ b/src/Modules/GraphQL/SchemaFilters.php
@@ -99,9 +99,10 @@ final class SchemaFilters implements Registrable {
 		// RenderedTemplate is a special case, as it already has the blocks resolved.
 		if ( RenderedTemplate::get_type_name() === $typename ) {
 			$fields['editorBlocks']['resolve'] = static function ( $node, $args ) {
-				if ( $args['flat'] ) {
+				if ( ! empty( $args['flat'] ) ) {
 					return ContentBlocksResolver::flatten_block_list( $node->parsed_blocks );
 				}
+
 				return $node->parsed_blocks;
 			};
 


### PR DESCRIPTION
## What
<!-- In a few words, what does this PR actually change -->
- This PR addresses a bug where the `flat: false` argument is ignored when using `templateByUri` to fetch editorBlocks. Instead, the results are always flattened due to how the model pre-builds the blocks. To resolve this issue, the code is updated to manually handle block flattening within the SchemaFilters logic.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->

- The bug was causing an incorrect response for the query for the blocks when the flat: false argument was passed. This fix ensures that the `flat: false` argument is respected, maintaining the desired block structure.

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of #456
-->
- Fixes #72 


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
- Added logic to explicitly handle the flattening of blocks based on the flat argument within the `SchemaFilters` context.
- Refactored the `flatten_block_list` `static` function to be made public for broader access (from `SchemaFilters`).
- Ensured that the flat argument is explicitly set to `false`.



## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->
#### When `flat:false`:
<img width="1074" alt="Screenshot 2025-02-24 at 5 29 28 PM" src="https://github.com/user-attachments/assets/3911116c-48ba-4702-b943-749d803c2682" />

#### When `flat:true`:
<img width="893" alt="Screenshot 2025-02-24 at 5 30 30 PM" src="https://github.com/user-attachments/assets/872f6dbe-d5d2-42a8-9d0d-65c70f6f7867" />




## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp-helper/blob/develop/.github/CONTRIBUTING.md
-->

- [ ] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [ ] My code is tested to the best of my abilities.
- [ ] My code passes all lints (PHPCS, PHPStan, ESLint, etc.). <!-- See the Contributing Guidelines for linting instructions -->
- [ ] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
- [ ] I have updated the project documentation as needed.
- [ ] I have added a changelog entry for my changes to `CHANGELOG.md`.
