### PR TITLE
ci: Unmute `WP_DEBUG_DISPLAY` during env creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](./README.md#updating-and-versi
 ## [Unreleased]
 
 - fix: Ensure `templateByUri.editorBlocks` respects the `flat` query arg.
-- fix: Unmute `WP_DEBUG_DISPLAY` during env creation
+- ci: Unmute `WP_DEBUG_DISPLAY` during env creation
 
 ## [0.1.0] - 2025-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](./README.md#updating-and-versi
 ## [Unreleased]
 
 - fix: Ensure `templateByUri.editorBlocks` respects the `flat` query arg.
+- fix: Unmute `WP_DEBUG_DISPLAY` during env creation
 
 ## [0.1.0] - 2025-02-19
 

--- a/bin/install-test-env.sh
+++ b/bin/install-test-env.sh
@@ -115,10 +115,6 @@ if [ "$WP_DEBUG" != $WP_DEBUG_CURRENT ]; then
 	wp config set WP_DEBUG $WP_DEBUG --raw --type=constant --quiet --allow-root
 	WP_DEBUG_RESULT=$(wp config get --type=constant --format=json WP_DEBUG  --allow-root | tr -d '\r')
 	echo -e "$(status_message "WP_DEBUG: $WP_DEBUG_RESULT...")"
-
-	wp config set WP_DEBUG_DISPLAY true --raw --type=constant --quiet --allow-root
-	WP_DEBUG_DISPLAY_RESULT=$(wp config get --type=constant --format=json WP_DEBUG_DISPLAY --allow-root | tr -d '\r')
-	echo -e "$(status_message "WP_DEBUG_DISPLAY: $WP_DEBUG_DISPLAY_RESULT...")"
 fi
 
 # Disable Update Checks

--- a/bin/install-test-env.sh
+++ b/bin/install-test-env.sh
@@ -116,9 +116,9 @@ if [ "$WP_DEBUG" != $WP_DEBUG_CURRENT ]; then
 	WP_DEBUG_RESULT=$(wp config get --type=constant --format=json WP_DEBUG  --allow-root | tr -d '\r')
 	echo -e "$(status_message "WP_DEBUG: $WP_DEBUG_RESULT...")"
 
-	# @todo Unmute WP_DEBUG_DISPLAY
-	# @see https://github.com/wp-graphql/wp-graphql/issues/3239
-	wp config set WP_DEBUG_DISPLAY false --raw --type=constant --quiet --allow-root
+	wp config set WP_DEBUG_DISPLAY true --raw --type=constant --quiet --allow-root
+	WP_DEBUG_DISPLAY_RESULT=$(wp config get --type=constant --format=json WP_DEBUG_DISPLAY --allow-root | tr -d '\r')
+	echo -e "$(status_message "WP_DEBUG_DISPLAY: $WP_DEBUG_DISPLAY_RESULT...")"
 fi
 
 # Disable Update Checks


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->
## What
Unmute `WP_DEBUG_DISPLAY` in the test environment setup script to show debug messages on screen.

## Why
Debug messages were being suppressed in the test environment due to WP_DEBUG_DISPLAY being explicitly set to false. 

### Related Issue(s):
- Part of rtCamp/snapwp-helper 
Ref: #3239 (https://github.com/wp-graphql/wp-graphql/issues/3239)

## How
Modified the installation script to set WP_DEBUG_DISPLAY to true and added logging to confirm the setting was applied successfully.

Changes:
1. Changed `wp config set WP_DEBUG_DISPLAY false` to `wp config set WP_DEBUG_DISPLAY true`
2. Added confirmation output to display the current WP_DEBUG_DISPLAY value

## Testing Instructions
1. Delete your existing test environment (if applicable)
2. Run the installation script: `./bin/install-test-env.sh`
3. Check that WP_DEBUG_DISPLAY is set to true in the output
4. Verify in the wp-config.php file that WP_DEBUG_DISPLAY is set to true
5. Introduce a deliberate PHP error and confirm it displays on screen

## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->

## Additional Info
This change will make debug information visible on screen during development and testing. The WP_DEBUG setting itself remains configurable through the WP_DEBUG environment variable.

## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp-helper/blob/develop/.github/CONTRIBUTING.md
-->
- [x] I have read the [[Contribution Guidelines](https://claude.ai/DEVELOPMENT.md)](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [ ] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation as needed.
- [x] I have added a changelog entry for my changes to `CHANGELOG.md`.