### PR TITLE
chore: Remove unnecessary WP version checks

### DIFF
--- a/src/Modules/GraphQL/Data/ContentBlocksResolver.php
+++ b/src/Modules/GraphQL/Data/ContentBlocksResolver.php
@@ -278,11 +278,6 @@ final class ContentBlocksResolver {
 	 * @return array<string,mixed> The populated block.
 	 */
 	private static function populate_pattern_inner_blocks( array $block ): array {
-		// Bail if not WP 6.6 or later.
-		if ( ! function_exists( 'resolve_pattern_blocks' ) ) {
-			return $block;
-		}
-
 		if ( 'core/pattern' !== $block['blockName'] || ! isset( $block['attrs']['slug'] ) ) {
 			return $block;
 		}

--- a/src/Modules/GraphQL/Utils/ScriptModuleUtils.php
+++ b/src/Modules/GraphQL/Utils/ScriptModuleUtils.php
@@ -38,11 +38,6 @@ final class ScriptModuleUtils {
 	 * @return array<string,ScriptModuleData>|null
 	 */
 	public static function get_enqueued_script_modules(): ?array {
-		// Check for WP 6.5+ compatibility.
-		if ( ! function_exists( 'wp_script_modules' ) ) {
-			return null;
-		}
-
 		$modules = wp_script_modules();
 
 		$reflector = new \ReflectionClass( $modules );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
Remove unnecessary WordPress version checks since we now only support WordPress 6.7+.

## Why
These compatibility checks are no longer needed as our minimum WordPress version requirement is now 6.7+. Removing these checks simplifies the codebase and improves readability.

### Related Issue(s):
- Part of rtCamp/snapwp-helper

## How
- Removed `function_exists('wp_script_modules')` check in `get_enqueued_script_modules()` method as this function was introduced in WP 6.5
- Removed `function_exists('resolve_pattern_blocks')` check in `populate_pattern_inner_blocks()` method as this function was introduced in WP 6.6
- Updated return types and removed conditional early returns where applicable

## Testing Instructions
1. Run the plugin on WordPress 6.7+
2. Verify that script modules are properly loaded and pattern inner blocks are properly populated
3. Run existing tests to confirm nothing is broken

## Screenshots
<!-- N/A for this PR -->

## Additional Info
This is part of our effort to modernize the codebase by removing legacy compatibility code that's no longer needed.

## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp-helper/blob/develop/.github/CONTRIBUTING.md
-->
- [x] I have read the [[Contribution Guidelines](https://claude.ai/DEVELOPMENT.md)](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.).
- [x] My code has detailed inline documentation.
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation as needed.
- [x] I have added a changelog entry for my changes to `CHANGELOG.md`.