### PR TITLE
fix : Flatten blocks when `flat` arg is not provided.

### DIFF
--- a/src/Modules/GraphQL/SchemaFilters.php
+++ b/src/Modules/GraphQL/SchemaFilters.php
@@ -100,11 +100,11 @@ final class SchemaFilters implements Registrable {
 		if ( RenderedTemplate::get_type_name() === $typename ) {
 			$fields['editorBlocks']['resolve'] = static function ( $node, $args ) {
 				// Since blocks are preresolved by `templatebyUri`, may need to flatten them.
-				if ( empty( $args['flat'] ) ) {
-					return $node->parsed_blocks;
-				}
+				$should_flatten_blocks = ! isset( $args['flat'] ) || $args['flat'];
 
-				return ContentBlocksResolver::flatten_block_list( $node->parsed_blocks );
+				return $should_flatten_blocks
+					? ContentBlocksResolver::flatten_block_list( $node->parsed_blocks )
+					: $node->parsed_blocks;
 			};
 
 			return $fields;

--- a/tests/Integration/TemplateByUriQueryTest.php
+++ b/tests/Integration/TemplateByUriQueryTest.php
@@ -132,12 +132,12 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 	/**
 	 * The GraphQL query string to use for editor blocks.
 	 */
-	protected function editor_blocks_query(): string {
+	protected function editor_blocks_query( $flat='' ): string {
 		return '
-		query GetCurrentTemplate( $uri: String!, $flat: Boolean ) {
+		query GetCurrentTemplate( $uri: String! ) {
 			templateByUri( uri: $uri ) {
 				id
-				editorBlocks(flat: $flat) {
+				editorBlocks' . $flat . ' {
 					parentClientId
 				}
 			}
@@ -1066,12 +1066,11 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 
 		// Get the post URL and the query.
 		$post_url = get_permalink( $post_id );
-		$query    = $this->editor_blocks_query();
-
-		// 1. Test the query with the flat argument set to null.
+		// 1. Test the query with no flat argument set.
+		
+		$query         = $this->editor_blocks_query();
 		$variables     = [
 			'uri'  => wp_make_link_relative( $post_url ),
-			'flat' => null,
 		];
 		$actual        = $this->graphql( compact( 'query', 'variables' ) );
 		$editor_blocks = $actual['data']['templateByUri']['editorBlocks'];
@@ -1079,17 +1078,12 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		// Assert that the query was successful and the editor blocks are returned.
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotEmpty( $editor_blocks );
-		$this->assertCount( 3, $editor_blocks );
-
-		// Assert that the editor blocks are not flattened.
-		foreach ( range( 0, 2 ) as $index ) {
-			$this->assertNull( $editor_blocks[ $index ]['parentClientId'] );
-		}
+		$this->assertCount( 88, $editor_blocks );
 
 		// 2. Test the query with the flat argument set to false.
+		$query         = $this->editor_blocks_query( '(flat : false)' );
 		$variables     = [
 			'uri'  => wp_make_link_relative( $post_url ),
-			'flat' => false,
 		];
 		$actual        = $this->graphql( compact( 'query', 'variables' ) );
 		$editor_blocks = $actual['data']['templateByUri']['editorBlocks'];
@@ -1105,9 +1099,9 @@ class TemplateByUriQueryTest extends \Tests\WPGraphQL\TestCase\WPGraphQLTestCase
 		}
 
 		// 3. Test the query with the flat argument set to true.
+		$query         = $this->editor_blocks_query( '(flat : true)' );
 		$variables     = [
 			'uri'  => wp_make_link_relative( $post_url ),
-			'flat' => true,
 		];
 		$actual        = $this->graphql( compact( 'query', 'variables' ) );
 		$editor_blocks = $actual['data']['templateByUri']['editorBlocks'];


### PR DESCRIPTION
## What
<!-- In a few words, what does this PR actually change -->
- This PR fixes the bug to flatten the blocks list for the edge case when no `flat` argument is provided.
- This PR updates integration tests for testing the no flat args passed edge case.


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
- Current implementation is giving a `non-flat` list of blocks for the case of no `flat` args present in the query whereas the behaviour should be of returning the flattened lists.

## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
- The current implementation makes use of the `empty()` PHP function which is not able to differentiate between `flat:false` and `no flat arg present`. 
- This PR makes use of `isset()` to check if `flat` arg is passed or not.




## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->
#### `( flat : true )`
<img width="1164" alt="Screenshot 2025-03-03 at 7 36 21 PM" src="https://github.com/user-attachments/assets/51d96edd-09ee-454a-94ab-f05f1d1b0440" />

#### `( flat : false )`
<img width="1163" alt="Screenshot 2025-03-03 at 7 36 44 PM" src="https://github.com/user-attachments/assets/69eaf4c0-500f-44d9-9e65-6c265baf73b5" />

#### `no arg passed`
<img width="1082" alt="Screenshot 2025-03-03 at 7 37 05 PM" src="https://github.com/user-attachments/assets/6b1b480c-052f-45c6-9269-1014af25adde" />


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp-helper/blob/develop/.github/CONTRIBUTING.md
-->

- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [ ] I have updated the project documentation as needed.
- [ ] I have added a changelog entry for my changes to `CHANGELOG.md`.
