### PR TITLE
ci: Update 3rd-party GH Actions to a pinned commit hash for security

### DIFF
--- a/.github/workflows/perform-lints.yml
+++ b/.github/workflows/perform-lints.yml
@@ -107,7 +107,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401  # 2.32.0@v2
               with:
                   php-version: '8.2'
                   coverage: none
@@ -115,7 +115,7 @@ jobs:
 
             # Install/cache composer dependencies
             - name: Install dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565  # v3.1.0@v3
               with:
                   composer-options: '--no-progress'
 
@@ -140,7 +140,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401  # 2.32.0@v2
               with:
                   php-version: '8.2'
                   extensions: mbstring, intl
@@ -149,7 +149,7 @@ jobs:
 
             # Install/cache composer dependencies
             - name: Install dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565  # v3.1.0@v3
               with:
                   composer-options: '--no-progress'
 
@@ -203,7 +203,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Install PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401  # 2.32.0@v2
               with:
                   php-version: ${{ matrix.php }}
                   extensions: json, mbstring
@@ -211,7 +211,7 @@ jobs:
 
             # Install/cache composer dependencies
             - name: Install dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565  # v3.1.0@v3
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -258,7 +258,7 @@ jobs:
 
             - name: Push coverage to Coveralls.io
               if: matrix.coverage == 1
-              uses: coverallsapp/github-action@v2
+              uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b  # v2.3.6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   file: tests/_output/Integration-coverage.xml
@@ -267,7 +267,7 @@ jobs:
 
             - name: Push coverage to CodeClimate
               if: matrix.coverage == 1
-              uses: paambaati/codeclimate-action@v9
+              uses: paambaati/codeclimate-action@f429536ee076d758a24705203199548125a28ca7  # v9.0.0
               env:
                   CC_TEST_REPORTER_ID: d16e661bd765b428e1b7bde991152367616a6511fab735cbb459976ec54096a0
               with:
@@ -286,14 +286,14 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401  # 2.32.0@v2
               with:
                   php-version: '8.2'
                   coverage: none
                   tools: composer
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565  # v3.1.0@v3
               with:
                   composer-options: '--no-progress'
 
@@ -357,7 +357,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup PHP w/ Composer & WP-CLI
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401  # 2.32.0@v2
               with:
                   php-version: 8.2
                   extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
@@ -365,7 +365,7 @@ jobs:
                   tools: composer:v2, wp-cli
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565  # v3.1.0@v3
               with:
                   composer-options: '--no-progress'
 
@@ -405,7 +405,7 @@ jobs:
                   graphql-schema-linter /tmp/schema.graphql || true
 
             - name: Get Latest tag
-              uses: actions-ecosystem/action-get-latest-tag@v1
+              uses: actions-ecosystem/action-get-latest-tag@b7c32daec3395a9616f88548363a42652b22d435  # v1.6.0
               id: get-latest-tag
 
             - name: Test Schema for breaking changes

--- a/.github/workflows/perform-lints.yml
+++ b/.github/workflows/perform-lints.yml
@@ -51,7 +51,7 @@ jobs:
 
             - name: Determine modified files for PR
               id: changed-files
-              uses: tj-actions/changed-files@v44
+              uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # @v46.0.1
               with:
                   # We are only interested in PHP, JS, and workflow files.
                   files_yaml: |

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -18,7 +18,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401  # 2.32.0@v2
               with:
                   php-version: 7.4
                   coverage: none
@@ -26,7 +26,7 @@ jobs:
                   tools: composer:v2
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565  # v3.1.0@v3
               with:
                   composer-options: '--no-progress'
 
@@ -54,7 +54,7 @@ jobs:
                   path: snapwp-helper.zip
 
             - name: Upload release asset
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
               with:
                   files: snapwp-helper.zip
               env:

--- a/.github/workflows/upload-schema-artifact.yml
+++ b/.github/workflows/upload-schema-artifact.yml
@@ -26,7 +26,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Setup PHP w/ Composer & WP-CLI
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401  # 2.32.0@v2
               with:
                   php-version: 8.2
                   extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
@@ -34,7 +34,7 @@ jobs:
                   tools: composer:v2, wp-cli
 
             - name: Install Composer dependencies
-              uses: ramsey/composer-install@v3
+              uses: ramsey/composer-install@a2636af0004d1c0499ffca16ac0b4cc94df70565  # v3.1.0@v3
               with:
                   composer-options: '--no-progress'
 
@@ -66,7 +66,7 @@ jobs:
                   wp graphql generate-static-schema --allow-root
 
             - name: Upload schema as release artifact
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
               with:
                   files: /tmp/schema.graphql
               env:


### PR DESCRIPTION
This update replaces the version reference for `tj-actions/changed-files` with a pinned commit hash from the latest tag. This change mitigates the risk posed by the recent security compromise (CVE-2025-30066), as outlined in the following reports:  

- [Wiz.io: GitHub Action Supply Chain Attack](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066)  
- [StepSecurity: Compromise Detection](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)  

Pinning the commit ensures that only a verified version of the action is used, reducing exposure to potential malicious updates.