### PR TITLE
Update `tj-actions/changed-files` to a pinned commit hash for security

### DIFF
--- a/.github/workflows/perform-lints.yml
+++ b/.github/workflows/perform-lints.yml
@@ -51,7 +51,7 @@ jobs:
 
             - name: Determine modified files for PR
               id: changed-files
-              uses: tj-actions/changed-files@v44
+              uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # @v46.0.1
               with:
                   # We are only interested in PHP, JS, and workflow files.
                   files_yaml: |


### PR DESCRIPTION
This update replaces the version reference for `tj-actions/changed-files` with a pinned commit hash from the latest tag. This change mitigates the risk posed by the recent security compromise (CVE-2025-30066), as outlined in the following reports:  

- [Wiz.io: GitHub Action Supply Chain Attack](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066)  
- [StepSecurity: Compromise Detection](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised)  

Pinning the commit ensures that only a verified version of the action is used, reducing exposure to potential malicious updates.