### PR TITLE
feat : Expose and test `is404` on RenderedTemplate and Model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](./README.md#updating-and-versioning).
 
+## Unreleased
+
+- feat: Expose `is404` field on `RenderedTemplate` GraphQL type and model.
+
 ## [0.2.2] - 2025-03-31
 
 This _minor_ release adds support for the `generalSettings.siteIcon` field in the schema, and updates the EnvGenerator variables to reflect the latest requirements by the SnapWP Framework.

--- a/src/Modules/GraphQL/Model/RenderedTemplate.php
+++ b/src/Modules/GraphQL/Model/RenderedTemplate.php
@@ -142,6 +142,9 @@ class RenderedTemplate extends Model {
 					return $queue;
 				},
 				'uri'                        => fn (): ?string => ! empty( $this->data['uri'] ) ? $this->data['uri'] : null,
+				'is404'                      => static function (): bool {
+					return is_404();
+				},
 			];
 		}
 	}

--- a/src/Modules/GraphQL/Type/WPObject/RenderedTemplate.php
+++ b/src/Modules/GraphQL/Type/WPObject/RenderedTemplate.php
@@ -74,6 +74,13 @@ final class RenderedTemplate extends AbstractObject implements TypeWithConnectio
 					return ! empty( $source->uri ) ? $context->node_resolver->resolve_uri( $source->uri ) : null;
 				},
 			],
+			'is404'         => [
+				'type'        => 'Boolean',
+				'description' => __( 'Whether the template is a 404 page.', 'snapwp-helper' ),
+				'resolve'     => static function () {
+					return is_404();
+				},
+			],
 		];
 	}
 

--- a/tests/Integration/TemplateByUriQueryTest.php
+++ b/tests/Integration/TemplateByUriQueryTest.php
@@ -111,6 +111,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		return 'query testTemplateByUri( $uri: String! ) {
 			templateByUri(uri: $uri) {
 				bodyClasses
+				is404
 				connectedNode {
 					__typename
 					isPostsPage
@@ -173,6 +174,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 
 		// 2. Test a good URI.
 		$post_link = get_permalink( $post_id );
@@ -228,6 +230,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 
 		// 2. Test a valid URI for the parent page.
 		$parent_page_link = get_permalink( $parent_page_id );
@@ -301,6 +304,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 
 		// Test a good URI.
 		$cpt_link = get_permalink( $cpt_id );
@@ -347,6 +351,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 
 		// Test a good URI.
 		$category_link = get_term_link( $category_id );
@@ -392,6 +397,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 
 		// Test a good URI.
 		$tag_link = get_tag_link( $tag_id );
@@ -436,6 +442,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 
 		// Test a good URI.
 		$term_link = get_term_link( $term_id );
@@ -514,6 +521,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 
 		// Test a good URI.
 		$archive_link = get_post_type_archive_link( 'non_hierarchical_cpt' );
@@ -567,6 +575,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 
 		// Test a good URI for the parent post archive.
 		$archive_link = get_post_type_archive_link( 'hierarchical_cpt' );
@@ -618,6 +627,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 
 		// Test invalid archive URIs.
 		$invalid_uris = [
@@ -733,6 +743,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertArrayNotHasKey( 'errors', $actual );
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered date archive template' );
 		$this->assertContains( 'date', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the date class' );
+		$this->assertFalse( $actual['data']['templateByUri']['is404'], 'Should not be a 404.' );
 	}
 
 	/**
@@ -767,6 +778,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertNotEmpty( $actual['data']['templateByUri'], 'templateByUri should return the rendered 404 template' );
 		$this->assertContains( 'error404', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the error404 class' );
 		$this->assertNull( $actual['data']['templateByUri']['connectedNode'], 'connectedNode should be null' );
+		$this->assertTrue( $actual['data']['templateByUri']['is404'], 'Should be a 404.' );
 	}
 
 	/**
@@ -978,6 +990,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertEquals( 'Page', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a Page' );
 		$this->assertEquals( $front_page_id, $actual['data']['templateByUri']['connectedNode']['databaseId'], 'connectedNode should have the correct databaseId' );
 		$this->assertEquals( 'Front Page Test', $actual['data']['templateByUri']['connectedNode']['title'], 'connectedNode should have the correct title' );
+		$this->assertFalse( $actual['data']['templateByUri']['is404'], 'Should not be a 404.' );
 
 		// Test posts archive URI.
 		$posts_page_uri = wp_make_link_relative( get_permalink( $posts_page_id ) );
@@ -1037,6 +1050,7 @@ class TemplateByUriQueryTest extends IntegrationTestCase {
 		$this->assertContains( 'blog', $actual['data']['templateByUri']['bodyClasses'], 'bodyClasses should contain the blog class' );
 		$this->assertEquals( 'ContentType', $actual['data']['templateByUri']['connectedNode']['__typename'], 'connectedNode should be a PostsPage' );
 		$this->assertTrue( $actual['data']['templateByUri']['connectedNode']['isPostsPage'], 'connectedNode should be a posts page' );
+		$this->assertFalse( $actual['data']['templateByUri']['is404'], 'Should not be a 404.' );
 
 		// Clean up: Restore the original options.
 		update_option( 'page_on_front', $original_page_on_front );


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
- This PR exposes the `is404` field to the GraphQL schema on both the `RenderedTemplate` GraphQL object and the model.
- It also adds test coverage to verify that `is404` returns false for non-404 `templateByUri` queries.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
- The `is404` field is essential to determine if a template corresponds to a 404 page.

### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of #456
-->
- Closes [Task: [snapwp-helper] add/test is_404() is false on any other templateByUri query test](https://github.com/rtCamp/headless/issues/452)


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
- Add the `is404` field to the `RenderedTemplate` GraphQL type.
- Add the native `is_404()` function to the model's callback.
- Add integration tests in `TemplateByUriTest.php` to assert that `is404` graphql field is false for all valid (non-404) templates and true for the 404ed templates, queried using `templateByUri`.


## Screenshots
<!-- Include relevant screenshots proving the PR works as intended. -->
### For `non-404` URIs returns `false`. ✅ 
<img width="793" alt="Screenshot 2025-04-11 at 4 20 21 PM" src="https://github.com/user-attachments/assets/456c9b89-c786-4223-8396-72cac019e417" />

### For `404` URIs returns `true`.
<img width="802" alt="Screenshot 2025-04-11 at 4 20 49 PM" src="https://github.com/user-attachments/assets/444712b5-fd91-4182-ae4a-5e6d76cb7a53" />


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp-helper/blob/develop/.github/CONTRIBUTING.md
-->

- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation as needed.
- [x] I have added a changelog entry for my changes to `CHANGELOG.md`.
