### PR TITLE
fix : Remove the translation functions that are triggering notices in WP6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](./README.md#updating-and-versi
 
 ## Unreleased
 
+- fix: Avoid translation calls before `init` action.
 - feat: Expose `is404` field on `RenderedTemplate` GraphQL type and model.
 - feat: Expose `GlobalStyles.bigImageSizeThreshold` field to the GraphQL schema.
 

--- a/bin/install-test-env.sh
+++ b/bin/install-test-env.sh
@@ -55,7 +55,7 @@ fi
 # Install WordPress.
 echo -e "$(status_message "Installing WordPress...")"
 
-wp core install --title="$SITE_TITLE" --admin_user="$WORDPRESS_ADMIN_USER" --admin_password="$WORDPRESS_ADMIN_PASSWORD" --admin_email=admin@test.local --skip-email --url="$WORDRESS_URL:$BUILTIN_SERVER_PORT" --allow-root
+wp core install --title="$SITE_TITLE" --admin_user="$WORDPRESS_ADMIN_USER" --admin_password="$WORDPRESS_ADMIN_PASSWORD" --admin_email=admin@test.local --skip-email --url="$WORDPRESS_URL" --allow-root
 
 wp core update-db --allow-root
 

--- a/src/Modules/GraphQL.php
+++ b/src/Modules/GraphQL.php
@@ -90,7 +90,7 @@ class GraphQL implements Module {
 
 		return [
 			'slug'           => 'wp-graphql',
-			'name'           => __( 'WPGraphQL', 'snapwp-helper' ),
+			'name'           => 'WPGraphQL',
 			'check_callback' => static function () use ( $minimum_version ) {
 				// WPGraphQL must be active.
 				if ( ! class_exists( 'WPGraphQL' ) || ! defined( 'WPGRAPHQL_VERSION' ) ) {
@@ -127,7 +127,7 @@ class GraphQL implements Module {
 
 		return [
 			'slug'           => 'wp-graphql-content-blocks',
-			'name'           => __( 'WPGraphQL Content Blocks', 'snapwp-helper' ),
+			'name'           => 'WPGraphQL Content Blocks',
 			'check_callback' => static function () use ( $minimum_version ) {
 				// WPGraphQL Content Blocks must be active.
 				if ( ! class_exists( 'WPGraphQLContentBlocks' ) || ! defined( 'WPGRAPHQL_CONTENT_BLOCKS_VERSION' ) ) {


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
Please make sure to review the [Contribution Guidelines](../DEVELOPMENT.md) before submitting your PR.
-->

## What
<!-- In a few words, what does this PR actually change -->
This PR fixes a WordPress core notice related to early translation loading by removing the use of __() in `get_wpgraphql_dependency_args()` and `get_wpgraphql_content_blocks_dependency_args()` methods inside the GraphQL module.


## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too. -->
In WordPress 6.8-rc3, calling translation functions like __() before the init hook triggers a notice:

> Notice: Function `_load_textdomain_just_in_time` was called incorrectly. Translation loading for the snapwp-helper domain was triggered too early.

This happens because the plugin was using `__()` too early during its load process — before WordPress was ready to load translation files.


### Related Issue(s):
<!-- E.g.
- Fixes | Closes | Part of #456
-->
- Part of [https://github.com/rtCamp/headless/issues/448](https://github.com/rtCamp/headless/issues/448)


## How
<!-- How does your PR address the issue at hand? What are the implementation details? Please be specific. -->
The name values in the dependency arrays are now passed as plain strings without translation wrappers (e.g., `'WPGraphQL' `instead of `__( 'WPGraphQL', 'snapwp-helper' )`). These labels are meant for internal use and don’t require translation.


## Checklist
<!--
We encourage you to complete this checklist to the best of your abilities.
If you can't do everything, that's okay too.
Contributing Guidelines: https://github.com/rtCamp/snapwp-helper/blob/develop/.github/CONTRIBUTING.md
-->

- [x] I have read the [Contribution Guidelines](../DEVELOPMENT.md).
- [x] My code is tested to the best of my abilities.
- [x] My code passes all lints (PHPCS, PHPStan, ESLint, etc.). <!-- See the Contributing Guidelines for linting instructions -->
- [x] My code has detailed inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] I have updated the project documentation as needed.
- [x] I have added a changelog entry for my changes to `CHANGELOG.md`.
