### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
             - develop
     workflow_dispatch:
 name: Deploying Headless Server
+permissions:
+    contents: read
 env:
     # Please keep in install-links to avoid npm install errors on the server
     build-command: npm i --include-dev --install-links && npm run build:dist


### PR DESCRIPTION
Potential fix for [https://github.com/rtCamp/snapwp-helper/security/code-scanning/1](https://github.com/rtCamp/snapwp-helper/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` to allow the workflow to read repository contents.
- Additional permissions (e.g., `pull-requests: write`) can be added if required by specific steps.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `deploy` job to limit permissions to that specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
